### PR TITLE
Use into_cow feature to fix compile errors in latest Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! See the examples directory for some examples to get you started.
 
-#![feature(unsafe_destructor, alloc, core, libc, io_ext)]
+#![feature(unsafe_destructor, alloc, core, libc, io_ext, into_cow)]
 #![cfg_attr(test, feature(io))]
 
 extern crate libc;


### PR DESCRIPTION
Library currently fails to compile due to feature-gated `into_cow`. Adding the feature fixes the errors.