### PR TITLE
Make MessageItem::new_array() return a Result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub use ffi::DBusRequestNameReply as RequestNameReply;
 pub use ffi::DBusReleaseNameReply as ReleaseNameReply;
 pub use ffi::DBusMessageType as MessageType;
 
-pub use message::{Message, MessageItem, OwnedFd};
+pub use message::{Message, MessageItem, OwnedFd, ArrayError};
 pub use prop::PropHandler;
 pub use prop::Props;
 


### PR DESCRIPTION
As rust main intention is to be secure, the behavior of the code should be reflected by the code and instead of the documentation.
This patch makes `MessageItem::new_array()` return a `Result` instead of panicking i.e. when the vector is emtpy, so you must explicitly call `MessageItem::new_array().unwrap()` in your code which makes potential side effects obvious.