### PR TITLE
Compliance to RFC1214

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -402,7 +402,7 @@ impl From<(MessageItem, MessageItem)> for MessageItem {
 }
 
 /// Helper trait for `MessageItem::inner()`
-pub trait FromMessageItem<'a> {
+pub trait FromMessageItem<'a> :Sized {
     fn from(i: &'a MessageItem) -> Result<Self, ()>;
 }
 


### PR DESCRIPTION
Hi, the current 1.4 nightly introduces [RFC1214](https://github.com/rust-lang/rfcs/blob/master/text/1214-projections-lifetimes-and-wf.md#impact-on-cratesio) which causes `trait MessageItem` to produce a warning. This warning will become a hard error in the next release. Here is the fix, tests still run.