### PR TITLE
Make import Rust 1.3 compatible

### DIFF
--- a/src/methoddisp.rs
+++ b/src/methoddisp.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
 use {MessageItem, Message, MessageType, Connection, ConnectionItem, Error, ErrorName};
-use {Signature, Member, Path, Interface as IfaceName};
+use {Signature, Member, Path};
+use Interface as IfaceName;
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 use std::collections::BTreeMap;


### PR DESCRIPTION
The current code does not compile on my machine (with Rust v1.3).
Could it be that you are using Rust v1.4?
This pull-request fixed a syntax error in an import statement.