### PR TITLE
Enable missing_docs warning and add missing docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //! See the examples directory for some examples to get you started.
 
+#![warn(missing_docs)]
+
 extern crate libc;
 
 pub use ffi::DBusBusType as BusType;
@@ -31,6 +33,7 @@ use std::cell::{Cell, RefCell};
 use std::mem;
 use std::os::unix::io::RawFd;
 
+#[allow(missing_docs)]
 mod ffi;
 mod message;
 mod prop;
@@ -107,6 +110,7 @@ fn to_c_str(n: &str) -> CString { CString::new(n.as_bytes()).unwrap() }
 
 impl Error {
 
+    /// Create a new custom D-Bus Error.
     pub fn new_custom(name: &str, message: &str) -> Error {
         let n = to_c_str(name);
         let m = to_c_str(&message.replace("%","%%"));
@@ -320,6 +324,7 @@ impl Connection {
         Ok(serial)
     }
 
+    /// Get the connection's unique name.
     pub fn unique_name(&self) -> String {
         let c = unsafe { ffi::dbus_bus_get_unique_name(self.conn()) };
         c_str_to_slice(&c).unwrap_or("").to_string()
@@ -333,6 +338,7 @@ impl Connection {
         }
     }
 
+    /// Register an object path.
     pub fn register_object_path(&self, path: &str) -> Result<(), Error> {
         let mut e = Error::empty();
         let p = to_c_str(path);
@@ -351,12 +357,14 @@ impl Connection {
         if r == 0 { Err(e) } else { Ok(()) }
     }
 
+    /// Unregister an object path.
     pub fn unregister_object_path(&self, path: &str) {
         let p = to_c_str(path);
         let r = unsafe { ffi::dbus_connection_unregister_object_path(self.conn(), p.as_ptr()) };
         if r == 0 { panic!("Out of memory"); }
     }
 
+    /// List registered object paths.
     pub fn list_registered_object_paths(&self, path: &str) -> Vec<String> {
         let p = to_c_str(path);
         let mut clist: *mut *mut libc::c_char = ptr::null_mut();
@@ -377,6 +385,7 @@ impl Connection {
         v
     }
 
+    /// Register a name.
     pub fn register_name(&self, name: &str, flags: u32) -> Result<RequestNameReply, Error> {
         let mut e = Error::empty();
         let n = to_c_str(name);
@@ -384,6 +393,7 @@ impl Connection {
         if r == -1 { Err(e) } else { Ok(unsafe { mem::transmute(r) }) }
     }
 
+    /// Release a name.
     pub fn release_name(&self, name: &str) -> Result<ReleaseNameReply, Error> {
         let mut e = Error::empty();
         let n = to_c_str(name);
@@ -391,6 +401,7 @@ impl Connection {
         if r == -1 { Err(e) } else { Ok(unsafe { mem::transmute(r) }) }
     }
 
+    /// Add a match rule to match messages on the message bus.
     pub fn add_match(&self, rule: &str) -> Result<(), Error> {
         let mut e = Error::empty();
         let n = to_c_str(rule);
@@ -398,6 +409,7 @@ impl Connection {
         if e.name().is_some() { Err(e) } else { Ok(()) }
     }
 
+    /// Remove a match rule to match messages on the message bus.
     pub fn remove_match(&self, rule: &str) -> Result<(), Error> {
         let mut e = Error::empty();
         let n = to_c_str(rule);

--- a/src/prop.rs
+++ b/src/prop.rs
@@ -11,6 +11,7 @@ pub struct Props<'a> {
 }
 
 impl<'a> Props<'a> {
+    /// Create a new Props.
     pub fn new<N, P, I>(conn: &'a Connection, name: N, path: P, interface: I, timeout_ms: i32) -> Props<'a>
     where N: Into<BusName>, P: Into<Path>, I: Into<Interface> {
         Props {
@@ -22,6 +23,7 @@ impl<'a> Props<'a> {
         }
     }
 
+    /// Get a single property's value.
     pub fn get(&self, propname: &str) -> Result<MessageItem, Error> {
         let mut m = Message::method_call(&self.name, &self.path,
             &"org.freedesktop.DBus.Properties".into(), &"Get".into());
@@ -37,6 +39,7 @@ impl<'a> Props<'a> {
        return Err(Error::new_custom("InvalidReply", &f));
     }
 
+    /// Set a single property's value.
     pub fn set(&self, propname: &str, value: MessageItem) -> Result<(), Error> {
         let mut m = Message::method_call(&self.name, &self.path,
             &"org.freedesktop.DBus.Properties".into(), &"Set".into());
@@ -46,6 +49,7 @@ impl<'a> Props<'a> {
         Ok(())
     }
 
+    /// Get a map of all the properties' names and their values.
     pub fn get_all(&self) -> Result<BTreeMap<String, MessageItem>, Error> {
         let mut m = Message::method_call(&self.name, &self.path,
             &"org.freedesktop.DBus.Properties".into(), &"GetAll".into());
@@ -77,24 +81,31 @@ pub struct PropHandler<'a> {
 }
 
 impl<'a> PropHandler<'a> {
+    /// Create a new PropHandler from a Props.
     pub fn new(p: Props) -> PropHandler {
         PropHandler { p: p, map: BTreeMap::new() }
     }
 
+    /// Get a map of all the properties' names and their values.
     pub fn get_all(&mut self) -> Result<(), Error> {
         self.map = try!(self.p.get_all());
         Ok(())
     }
 
+    /// Get a mutable reference to the PropHandler's fetched properties.
     pub fn map_mut(&mut self) -> &mut BTreeMap<String, MessageItem> { &mut self.map }
+
+    /// Get a reference to the PropHandler's fetched properties.
     pub fn map(&self) -> &BTreeMap<String, MessageItem> { &self.map }
 
+    /// Get a single property's value.
     pub fn get(&mut self, propname: &str) -> Result<&MessageItem, Error> {
         let v = try!(self.p.get(propname));
         self.map.insert(propname.to_string(), v);
         Ok(self.map.get(propname).unwrap())
     }
 
+    /// Set a single property's value.
     pub fn set(&mut self, propname: &str, value: MessageItem) -> Result<(), Error> {
         try!(self.p.set(propname, value.clone()));
         self.map.insert(propname.to_string(), value);

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -10,6 +10,7 @@ macro_rules! cstring_wrapper {
 
 
 impl $t {
+    /// Creates a new instance of this struct.
     pub fn new<S: Into<Vec<u8>>>(s: S) -> Result<$t, String> {
         let c = try!(CString::new(s).map_err(|e| e.to_string()));
         let mut e = Error::empty();

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -15,6 +15,7 @@ pub struct Watch {
 }
 
 impl Watch {
+    /// Get the RawFd this Watch is for
     pub fn fd(&self) -> RawFd { self.fd }
     /// Add POLLIN to events to listen for
     pub fn readable(&self) -> bool { self.read }


### PR DESCRIPTION
I got bored this afternoon and turned on the missing_docs warning for
everything except ffi. I've added minimal doc strings to satisfy the
doc check, although of course more complete descriptions would be great
to add at some point, too.

I also took the liberty of re-filling the line breaks of some existing
long docstrings.

Signed-off-by: Andy Grover <agrover@redhat.com>