### PR TITLE
Use pkg-config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,13 @@ documentation = "http://diwic.github.io/dbus-rs-docs/dbus"
 keywords = ["D-Bus", "DBus"]
 license = "Apache-2.0/MIT"
 
+build = "build.rs"
+
 [dependencies]
 libc = "0.2"
+
+[build-dependencies]
+pkg-config = "0.3"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+extern crate pkg_config;
+
+fn main() {
+    pkg_config::find_library("dbus-1").unwrap();
+}

--- a/src/msgarg.rs
+++ b/src/msgarg.rs
@@ -542,7 +542,7 @@ impl<'a> IterAppend<'a> {
 
     fn append_container<F: FnOnce(&mut IterAppend<'a>)>(&mut self, arg_type: i32, sig: Option<&CStr>, f: F) {
         let mut s = IterAppend(ffi_iter(), self.1);
-        let p = sig.map(|s| s.as_ref().as_ptr()).unwrap_or(ptr::null());
+        let p = sig.map(|s| s.as_ptr()).unwrap_or(ptr::null());
         check("dbus_message_iter_open_container",
             unsafe { ffi::dbus_message_iter_open_container(&mut self.0, arg_type, p, &mut s.0) });
         f(&mut s);


### PR DESCRIPTION
Hi! Please use `pkg-config` to link to native libraries. This is especially important on systems like FreeBSD, where the default linker `/usr/bin/ld` doesn't include `/usr/local/lib` in its default search path.

Also, this pull request fixes this:

```
src/msgarg.rs:545:31: 545:39 error: no method named `as_ref` found for type `&std::ffi::c_str::CStr` in the current scope
src/msgarg.rs:545         let p = sig.map(|s| s.as_ref().as_ptr()).unwrap_or(ptr::null());
                                                ^~~~~~~~
src/msgarg.rs:545:31: 545:39 note: the method `as_ref` exists but the following trait bounds were not satisfied: `std::ffi::c_str::CStr : core::convert::AsRef<_>`
```