### PR TITLE
Add Tree.add_and_reg() and Tree.remove_and_unreg()

### DIFF
--- a/src/methoddisp.rs
+++ b/src/methoddisp.rs
@@ -675,6 +675,20 @@ impl<M: MethodType> Tree<M> {
         self
     }
 
+    /// Add a Object Path to this Tree, and register it.
+    pub fn add_and_reg(&mut self, c: &Connection, p: ObjectPath<M>) -> Result<&mut Self, Error> {
+        try!(c.register_object_path(&*p.name));
+        self.paths.insert(p.name.clone(), Arc::new(p));
+        Ok(self)
+    }
+
+    /// Remove an Object Path from this Tree, and unregister it.
+    pub fn remove_and_unreg(&mut self, c: &Connection, p: ObjectPath<M>) -> &mut Self {
+        c.unregister_object_path(&**p.name);
+        self.paths.remove(&p.name);
+        self
+    }
+
     /// Registers or unregisters all object paths in the tree.
     pub fn set_registered(&self, c: &Connection, b: bool) -> Result<(), Error> {
         let mut regd_paths = Vec::new();


### PR DESCRIPTION
I want to be able to have a method that winds up creating or removing an objectpath from the tree (e.g. a Create method that results in a representation of the just-created thing, enumerable with objectmanager.)

Anyway, I haven't found a way for that method to be *in* the Tree itself (we'd need a &mut Tree in the method's closure) so what I've done is have two trees - one with the objectpath supporting an interface with Create and Destroy, and then another Tree (not within the first) that we can get a &mut for -- with some Rc, RefCell and closuring in the first one's methods -- where the objects themselves live.

OK great. Now the Create and Destroy methods just need a way to add or remove a single objectpath after initialization. The current add/set_registered methods don't really work for this, hence the new add_and_reg and remove_and_unreg methods. But they have their own downsides in that the two pairs of methods should really not be mixed, and `add_and_reg` isn't as chainable (?) as `add` is.

Anyway, please let me know what you think! :smile: thanks.