### PR TITLE
Add tree-wide data item

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It then listens for incoming D-Bus events and handles them accordingly.
 let c = Connection::get_private(BusType::Session).unwrap();
 c.register_name("com.example.dbustest", NameFlag::ReplaceExisting as u32).unwrap();
 let f = Factory::new_fn::<()>();
-let tree = f.tree().add(f.object_path("/hello", ()).introspectable().add(
+let tree = f.tree(()).add(f.object_path("/hello", ()).introspectable().add(
     f.interface("com.example.dbustest", ()).add_m(
         f.method("Hello", (), |m| {
             let s = format!("Hello {}!", m.msg.sender().unwrap());

--- a/examples/adv_server.rs
+++ b/examples/adv_server.rs
@@ -27,6 +27,7 @@ struct Device {
 #[derive(Copy, Clone, Default, Debug)]
 struct TData;
 impl tree::DataType for TData {
+    type Tree = ();
     type ObjectPath = Arc<Device>;
     type Property = ();
     type Interface = ();
@@ -126,7 +127,7 @@ fn create_tree(devices: &[Arc<Device>], iface: &Arc<Interface<MTFn<TData>, TData
     -> tree::Tree<MTFn<TData>, TData> {
 
     let f = tree::Factory::new_fn();
-    let mut tree = f.tree();
+    let mut tree = f.tree(());
     for dev in devices {
         tree = tree.add(f.object_path(dev.path.clone(), dev.clone())
             .introspectable()

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -29,7 +29,7 @@ fn main() {
     let signal2 = signal.clone();
 
     // We create a tree with one object path inside and make that path introspectable.
-    let tree = f.tree().add(f.object_path("/hello", ()).introspectable().add(
+    let tree = f.tree(()).add(f.object_path("/hello", ()).introspectable().add(
 
         // We add an interface to the object path...
         f.interface("com.example.dbustest", ()).add_m(

--- a/src/tree/factory.rs
+++ b/src/tree/factory.rs
@@ -4,7 +4,6 @@ use super::objectpath::IfaceCache;
 use std::sync::Arc;
 use Interface as IfaceName;
 use {Member, Path, arg};
-use std::default::Default;
 use std::cell::RefCell;
 
 /// The factory is used to create object paths, interfaces, methods etc.
@@ -86,8 +85,9 @@ impl<M: MethodType<D>, D: DataType> Factory<M, D> {
     }
 
     /// Creates a new tree.
-    pub fn tree(&self) -> Tree<M, D> { Default::default() }
- 
+    pub fn tree(&self, data: D::Tree) -> Tree<M, D> {
+        super::objectpath::new_tree(data)
+    }
 }
 
 

--- a/src/tree/factory.rs
+++ b/src/tree/factory.rs
@@ -108,6 +108,7 @@ fn fn_customdata() {
     #[derive(Default)]
     struct Custom;
     impl DataType for Custom {
+        type Tree = ();
         type ObjectPath = Arc<u8>;
         type Interface = ();
         type Property = ();

--- a/src/tree/leaves.rs
+++ b/src/tree/leaves.rs
@@ -438,6 +438,7 @@ fn test_prop_handlers() {
     #[derive(Default, Debug)]
     struct Custom;
     impl DataType for Custom {
+        type Tree = ();
         type ObjectPath = ();
         type Interface = ();
         type Property = i32;
@@ -446,7 +447,7 @@ fn test_prop_handlers() {
     }
 
     let f = Factory::new_fn::<Custom>();
-    let tree = f.tree().add(f.object_path("/test", ()).introspectable().object_manager()
+    let tree = f.tree(()).add(f.object_path("/test", ()).introspectable().object_manager()
         .add(f.interface("com.example.test", ())
             .add_p(f.property::<i32,_>("Value1", 5i32).default_get())
             .add_p(f.property::<i32,_>("Value2", 9i32).default_get())
@@ -502,7 +503,7 @@ fn test_set_prop() {
     let (setme1, setme2) = (setme.clone(), setme.clone());
 
     let f = Factory::new_fn::<()>();
-    let tree = f.tree().add(f.object_path("/example", ()).introspectable()
+    let tree = f.tree(()).add(f.object_path("/example", ()).introspectable()
         .add(f.interface("com.example.dbus.rs", ())
             .add_p(f.property::<i32,_>("changes", ())
                 .on_get(move |i, _| { i.append(changes1.get()); Ok(()) })) 
@@ -562,7 +563,7 @@ fn test_sync_prop() {
     let count = Arc::new(AtomicUsize::new(3));
     let (cget, cset) = (count.clone(), count.clone());
 
-    let tree1 = Arc::new(f.tree().add(f.object_path("/syncprop", ()).introspectable()
+    let tree1 = Arc::new(f.tree(()).add(f.object_path("/syncprop", ()).introspectable()
         .add(f.interface("com.example.syncprop", ())
             .add_p(f.property::<u32,_>("syncprop", ())
                 .access(Access::ReadWrite)

--- a/src/tree/methodtype.rs
+++ b/src/tree/methodtype.rs
@@ -60,6 +60,7 @@ pub type MethodResult = Result<Vec<Message>, MethodErr>;
 ///
 /// These currently require a debug bound, due to https://github.com/rust-lang/rust/issues/31518
 pub trait DataType: Sized + Default {
+    type Tree: fmt::Debug;
     type ObjectPath: fmt::Debug;
     type Property: fmt::Debug;
     type Interface: fmt::Debug + Default;
@@ -69,6 +70,7 @@ pub trait DataType: Sized + Default {
 
 /// No associated data for the tree.
 impl DataType for () {
+    type Tree = ();
     type ObjectPath = ();
     type Interface = ();
     type Property = ();

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -7,7 +7,7 @@
 //! let f = tree::Factory::new_fn::<()>();
 //! /* Add a method returning "Thanks!" on interface "com.example.dbus.rs"
 //!    on object path "/example". */
-//! let t = f.tree().add(f.object_path("/example", ()).introspectable()
+//! let t = f.tree(()).add(f.object_path("/example", ()).introspectable()
 //!     .add(f.interface("com.example.dbus.rs", ())
 //!         .add_m(f.method("CallMe", (), |m| {
 //!             Ok(vec!(m.msg.method_return().append("Thanks!"))) }

--- a/src/tree/objectpath.rs
+++ b/src/tree/objectpath.rs
@@ -432,7 +432,7 @@ fn test_introspection() {
             .add_s(f.signal("Echoed", ()).arg(("data", "s")).deprecated())
     );
 
-    let actual_result = t.introspect(&f.tree().add(f.object_path("/echo/subpath", ())));
+    let actual_result = t.introspect(&f.tree(()).add(f.object_path("/echo/subpath", ())));
     println!("\n=== Introspection XML start ===\n{}\n=== Introspection XML end ===", actual_result);
 
     let expected_result = r##"<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">

--- a/src/tree/objectpath.rs
+++ b/src/tree/objectpath.rs
@@ -297,7 +297,8 @@ pub fn new_objectpath<M: MethodType<D>, D: DataType>(n: Path<'static>, d: D::Obj
 /// A collection of object paths.
 #[derive(Debug, Default)]
 pub struct Tree<M: MethodType<D>, D: DataType> {
-    paths: ArcMap<Arc<Path<'static>>, ObjectPath<M, D>>
+    paths: ArcMap<Arc<Path<'static>>, ObjectPath<M, D>>,
+    data: D::Tree,
 }
 
 impl<M: MethodType<D>, D: DataType> Tree<M, D> {
@@ -380,6 +381,13 @@ impl<M: MethodType<D>, D: DataType> Tree<M, D> {
         }).collect()
     }
 
+    /// Get associated data
+    pub fn get_data(&self) -> &D::Tree { &self.data }
+
+}
+
+pub fn new_tree<M: MethodType<D>, D: DataType>(d: D::Tree) -> Tree<M, D> {
+    Tree { paths: ArcMap::new(), data: d }
 }
 
 /// An iterator adapter that handles incoming method calls.


### PR DESCRIPTION
Hi diwic, would being able to attach data to the overall tree also be useful?

We're using a `Rc<Refcell<T>>` to share ownership across each objectpath of our "dbus context", but it seems a little nicer if we could hook tree-wide stuff to the tree, and save the objectpath spot for objectpath-specific stuff. Thanks in advance.