### PR TITLE
Use metadeps to specify pkg-config dependencies declaratively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ build = "build.rs"
 libc = "0.2.7"
 
 [build-dependencies]
-pkg-config = "0.3"
+metadeps = "1"
 
 [dev-dependencies]
 tempdir = "0.3"
+
+[package.metadata.pkg-config]
+dbus-1 = "1.6"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
-extern crate pkg_config;
+extern crate metadeps;
 
 fn main() {
-    pkg_config::find_library("dbus-1").unwrap();
+    metadeps::probe().unwrap();
 }


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies.