### PR TITLE
Reimplement send_with_reply() using DBusPendingCall

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -146,6 +146,22 @@ extern "C" fn object_path_message_cb(conn: *mut ffi::DBusConnection, msg: *mut f
     ffi::DBusHandlerResult::Handled
 }
 
+extern "C" fn pending_call_cb<F: FnOnce(Message)>(pending: *mut ffi::DBusPendingCall, user_data: *mut c_void) {
+    let message = unsafe { ffi::dbus_pending_call_steal_reply(pending) };
+    assert!(!message.is_null());
+    let message = super::message::message_from_ptr(message, false);
+
+    let user_closure: *mut Option<Box<F>> = user_data as *mut Option<Box<F>>;
+    let user_closure = unsafe { (*user_closure).take().unwrap() };
+    (*user_closure)(message);
+}
+
+extern "C" fn pending_call_data_free_cb<F: FnOnce(Message)>(user_data: *mut c_void) {
+    let user_closure: *mut Option<Box<F>> = user_data as *mut Option<Box<F>>;
+    let user_closure = unsafe { Box::from_raw(user_closure) };
+    drop(user_closure)
+}
+
 impl Connection {
 
     #[inline(always)]
@@ -204,10 +220,39 @@ impl Connection {
         Ok(serial)
     }
 
-    /// Sends a message over the D-Bus. The resulting handler can be added to a connectionitem handler.
-    pub fn send_with_reply<'a, F: FnOnce(&Message) + 'a>(&self, msg: Message, f: F) -> MessageReply<F> {
-        let serial = self.send(msg).unwrap();
-        MessageReply(Some(f), serial)
+    /// Sends a message over the D-Bus without waiting, but calls the given closure when the reply is received.
+    pub fn send_with_reply<'a, F: FnOnce(Message) + 'a>(&self, mut msg: Message, f: F) -> Result<(),()> {
+        // Ensure allocation of a fresh serial, so that callbacks work as expected.
+        super::message::message_set_serial(&mut msg, 0);
+
+        let mut pc: *mut ffi::DBusPendingCall = ::std::ptr::null_mut();
+        let r = unsafe {
+            ffi::dbus_connection_send_with_reply(
+                self.conn(),
+                super::message::get_message_ptr(&msg),
+                &mut pc,
+                ffi::DBUS_TIMEOUT_INFINITE
+            )
+        };
+        if pc.is_null() { return Err(()); }
+        let pc = super::pending::pending_call_from_ptr(pc, false);
+        if r == 0 { return Err(()); }
+
+        let callback: Box<Option<Box<F>>> = Box::new(Some(Box::new(f)));
+        let callback = Box::into_raw(callback) as *mut c_void;
+        let r = unsafe {
+            ffi::dbus_pending_call_set_notify(
+                super::pending::get_pending_call_ptr(&pc),
+                Some(pending_call_cb::<F>),
+                callback,
+                Some(pending_call_data_free_cb::<F>)
+            )
+        };
+        if r == 0 {
+            drop(unsafe { Box::from_raw(callback) });
+            return Err(());
+        }
+        Ok(())
     }
 
     /// Get the connection's unique name.
@@ -377,21 +422,6 @@ pub struct MsgHandlerResult {
     pub reply: Vec<Message>,
 }
 
-pub struct MessageReply<F>(Option<F>, u32);
-
-impl<'a, F: FnOnce(&Message) + 'a> MsgHandler for MessageReply<F> {
-    fn handle_ci(&mut self, ci: &ConnectionItem) -> Option<MsgHandlerResult> {
-        if let ConnectionItem::MethodReturn(ref msg) = *ci {
-            if msg.get_reply_serial() == Some(self.1) {
-                self.0.take().unwrap()(msg);
-                return Some(MsgHandlerResult { handled: true, done: true, reply: Vec::new() })
-            }
-        }
-        None
-    }
-}
-
-
 #[test]
 fn message_reply() {
     use std::{cell, rc};
@@ -399,12 +429,12 @@ fn message_reply() {
     let m = Message::new_method_call("org.freedesktop.DBus", "/", "org.freedesktop.DBus", "ListNames").unwrap();
     let quit = rc::Rc::new(cell::Cell::new(false));
     let quit2 = quit.clone();
-    let reply = c.send_with_reply(m, move |result| {
+    c.send_with_reply(m, move |result| {
         let r = result;
         let _: ::arg::Array<&str, _>  = r.get1().unwrap();
         quit2.set(true);
-    });
-    for _ in c.iter(1000).with(reply) { if quit.get() { return; } }
+    }).unwrap();
+    for _ in c.iter(1000) { if quit.get() { return; } }
     assert!(false);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use std::os::raw::c_char;
 #[allow(missing_docs)]
 mod ffi;
 mod message;
+mod pending;
 mod prop;
 mod objpath;
 mod watch;

--- a/src/message.rs
+++ b/src/message.rs
@@ -900,8 +900,6 @@ impl<'a, C: ::std::ops::Deref<Target=Connection>> ConnPath<'a, C> {
     }
 }
 
-// For purpose of testing the library only.
-#[cfg(test)]
 pub fn message_set_serial(m: &mut Message, s: u32) {
     unsafe { ffi::dbus_message_set_serial(m.msg, s) };
 }

--- a/src/pending.rs
+++ b/src/pending.rs
@@ -1,0 +1,22 @@
+use super::ffi;
+
+pub struct PendingCall {
+    pc: *mut ffi::DBusPendingCall,
+}
+
+impl Drop for PendingCall {
+    fn drop(&mut self) {
+        unsafe { ffi::dbus_pending_call_unref(self.pc) };
+    }
+}
+
+pub fn pending_call_from_ptr(ptr: *mut ffi::DBusMessage, add_ref: bool) -> PendingCall {
+    if add_ref {
+        unsafe { ffi::dbus_pending_call_ref(ptr) };
+    }
+    PendingCall { pc: ptr }
+}
+
+pub fn get_pending_call_ptr<'a>(pc: &PendingCall) -> *mut ffi::DBusPendingCall {
+    pc.pc
+}


### PR DESCRIPTION
Current implementation of `send_with_reply()` relies on `send()` + adding the returned `MessageReply` to `msg_handlers()` array. There are a few downsides to this approach.

1. Makes user go through two steps to achieve the intended result.
2. Relies on `filter_message_cb()` not getting called until user adds `MessageReply` to `msg_handlers()`, otherwise the message will be missed and the handler will live forever. I.e. it lacks atomicity.
3. Doesn't handle `Error` replies at all, which means a leaked `MessageReply` per every failed call.
4. `send_with_reply()` is inconvenient to use while looping with `iter()`, because for some reason `msg_handlers()` is a property of `ConnectionItems`, not `Connection`, so the idiomatic `for i in c.iter(1000)` means the currently acting `ConnectionItems` is consumed, and so one can't call its `msg_handlers()` property from inside the loop, unless the loop is rewritten with manual use of `next()`.

This PR reimplements `send_with_reply()` in terms of `dbus_connection_send_with_reply()` and `DBusPendingCall`, so that none of the above is an issue anymore.

Downsides of this PR: `MessageReply` is removed altogether, and `send_with_reply()` has the return type changed. I.e. this is an API-breaking change.

Things to consider: If signature change is OK, maybe we should consider exposing the `timeout` parameter of `dbus_connection_send_with_reply()` too.