### PR TITLE
Add Method::inarg() to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ let f = Factory::new_fn::<()>();
 let tree = f.tree(()).add(f.object_path("/hello", ()).introspectable().add(
     f.interface("com.example.dbustest", ()).add_m(
         f.method("Hello", (), |m| {
-            let s = format!("Hello {}!", m.msg.sender().unwrap());
+            let s = format!("Hello {}!", m.msg.get1().unwrap());
             Ok(vec!(m.msg.method_return().append1(s)))
-        }).outarg::<&str,_>("reply")
+        }).inarg::<&str,_>("name")
+          .outarg::<&str,_>("reply")
     )
 ));
 tree.set_registered(&c, true).unwrap();

--- a/dbus-tokio/examples/tokio_server.rs
+++ b/dbus-tokio/examples/tokio_server.rs
@@ -53,7 +53,8 @@ fn main() {
                 // the callback receives "MethodInfo" struct and can return either an error, or a list of
                 // messages to send back.
                 let timer = Timer::default();
-                let sleep_future = timer.sleep(Duration::from_millis(500));
+                let t = m.msg.get1().unwrap();
+                let sleep_future = timer.sleep(Duration::from_millis(t));
 
                 // These are the variables we need after the timeout period. We need to 
                 // clone all strings now, because the tree might get destroyed during the sleep.
@@ -73,7 +74,8 @@ fn main() {
                 }).map_err(|e| MethodErr::failed(&e))
 
             // Our method has one output argument, no input arguments.
-            }).outarg::<&str,_>("reply")
+            }).inarg::<u32,_>("sleep_millis")
+              .outarg::<&str,_>("reply")
 
         // We also add the signal to the interface. This is mainly for introspection.
         ).add_s(signal2)


### PR DESCRIPTION
Sorry, I lost track of the issue #102.
I added some Method::inarg() calls to the examples to make it clear to new users how to use arguments.