### PR TITLE
Remove the metadeps dependency and bump version

### DIFF
--- a/libdbus-sys/Cargo.toml
+++ b/libdbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libdbus-sys"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["David Henningsson <diwic@ubuntu.com>"]
 
 description = "FFI bindings to libdbus."
@@ -13,7 +13,4 @@ categories = ["os::unix-apis", "external-ffi-bindings"]
 build = "build.rs"
 
 [build-dependencies]
-metadeps = "1"
-
-[package.metadata.pkg-config]
-dbus-1 = "1.6"
+pkg-config = "0.3"

--- a/libdbus-sys/build.rs
+++ b/libdbus-sys/build.rs
@@ -1,5 +1,5 @@
-extern crate metadeps;
+extern crate pkg_config;
 
 fn main() {
-    metadeps::probe().unwrap();
+    pkg_config::Config::new().atleast_version("1.6").probe("dbus-1").unwrap();
 }


### PR DESCRIPTION
Just use the pkg_config package directly instead of using the metadeps
one which requires an old version of toml.

cc @nox