### PR TITLE
Provide way to register connection with bus

### DIFF
--- a/dbus/src/connection.rs
+++ b/dbus/src/connection.rs
@@ -296,6 +296,18 @@ impl Connection {
         Self::conn_from_ptr(conn)
     }
 
+    /// Registers a new D-Bus connection with the bus.
+    ///
+    /// Note: `get_private` does this automatically, useful with `open_private`
+    pub fn register(&self) -> Result<(), Error> {
+        let mut e = Error::empty();
+        if !unsafe { ffi::dbus_bus_register(self.conn(), e.get_mut()) } {
+            Err(e)
+        } else {
+            Ok(())
+        }
+    }
+
     /// Gets whether the connection is currently open.
     pub fn is_connected(&self) -> bool {
         unsafe { ffi::dbus_connection_get_is_connected(self.conn()) }

--- a/libdbus-sys/src/lib.rs
+++ b/libdbus-sys/src/lib.rs
@@ -159,6 +159,7 @@ extern "C" {
         error: *mut DBusError);
     pub fn dbus_bus_remove_match(conn: *mut DBusConnection, rule: *const c_char,
         error: *mut DBusError);
+    pub fn dbus_bus_register(conn: *mut DBusConnection, error: *mut DBusError) -> bool;
 
     pub fn dbus_connection_close(conn: *mut DBusConnection);
     pub fn dbus_connection_dispatch(conn: *mut DBusConnection) -> DBusDispatchStatus;


### PR DESCRIPTION
Many bus connections require registration before methods can be called.
`Connection::get_private` does this automatically
(via `dbus_bus_get_private`), but `Connection::open_private`
(`dbus_connection_open_private`) does not.

Add `Connection::register` (which calls `dbus_bus_register`) so
`Connection`s created with `open_private` can register.