### PR TITLE
Add links attribute

### DIFF
--- a/libdbus-sys/Cargo.toml
+++ b/libdbus-sys/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["D-Bus", "DBus", "libdbus"]
 license = "Apache-2.0/MIT"
 categories = ["os::unix-apis", "external-ffi-bindings"]
 build = "build.rs"
+links = "dbus"
 
 [build-dependencies]
 metadeps = "1"

--- a/libdbus-sys/Cargo.toml
+++ b/libdbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libdbus-sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["David Henningsson <diwic@ubuntu.com>"]
 
 description = "FFI bindings to libdbus."


### PR DESCRIPTION
This add `links = "dbus"` key to `libdbus-sys`, so as to be able to override linkage with cargo/config.

https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts

This is a recommended practice, and is the easiest way to customize linking, which is helpful e.g. when cross-compiling (which metadeps/pkg-config doesn't readily handle). Unless there's a dedicated `[target.<arch-triple>.dbus]` config section in cargo/config, this key has no effect, so there are no contra-indications to adding it.

Someone on IRC mentioned having cross-compilation issue with this crate, so I thought to quickly fix that.

This PR also bumps libdbus-sys version to 0.1.3.