### PR TITLE
WIP: Mostly ported to futures 0.2

### DIFF
--- a/dbus-tokio/Cargo.toml
+++ b/dbus-tokio/Cargo.toml
@@ -12,13 +12,12 @@ categories = ["os::unix-apis", "api-bindings", "asynchronous"]
 
 [dependencies]
 dbus = { path = "../dbus", version = "0.6" }
-futures = "0.1.12"
+tokio-reactor = { version = "0.1.1", features = ["futures2"]}
+futures = "0.2.0-beta"
+futures-channel = "0.2.0-beta"
+futures-executor = "0.2.0-beta"
 mio = "0.6.9"
-tokio-core = "0.1.8"
 log = "0.3"
-
-[dev-dependencies]
-tokio-timer = "0.1.0"
 
 [badges]
 is-it-maintained-open-issues = { repository = "diwic/dbus-rs" }

--- a/dbus-tokio/src/lib.rs
+++ b/dbus-tokio/src/lib.rs
@@ -1,4 +1,4 @@
-//! Tokio integration for dbus
+//! Futures integration for dbus
 //!
 //! What's currently working is:
 //!
@@ -12,7 +12,9 @@
 
 extern crate dbus;
 extern crate futures;
-extern crate tokio_core;
+extern crate futures_channel;
+extern crate futures_executor;
+extern crate tokio_reactor;
 extern crate mio;
 
 #[macro_use]


### PR DESCRIPTION
Preliminary version of futures 0.2 support.
Not everything has ported; what's left is open for discussion.
Tokio hasn't officially announced their futures 0.2 support yet, [and it's not yet ready](https://github.com/tokio-rs/tokio/issues/251).

This was an experiment for me to see how far they were, and how simple dbus-rs could be ported.

I'm not sure how `PollEvented` works exactly; they do not have the `need_read` and `need_write` methods anymore, and I'm not sure what the replacement was.

---

To be done:

- [ ] Fix the `PollEvented` stuff. I'd like some input here.
- [ ] Patch the examples
- [ ] When Tokio has official support, pin the versions
- [ ] Make a breaking version change (version 0.3.0 or something)?
- [ ] Testing!