### PR TITLE
Migrate from tokio-core to tokio.

### DIFF
--- a/dbus-tokio/Cargo.toml
+++ b/dbus-tokio/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["os::unix-apis", "api-bindings", "asynchronous"]
 dbus = { path = "../dbus", version = "0.6" }
 futures = "0.1.12"
 mio = "0.6.9"
-tokio-core = "0.1.8"
+tokio = "0.1.7"
 log = "0.3"
 
 [dev-dependencies]
-tokio-timer = "0.1.0"
+tokio-timer = "0.2.4"
 
 [badges]
 is-it-maintained-open-issues = { repository = "diwic/dbus-rs" }

--- a/dbus-tokio/src/lib.rs
+++ b/dbus-tokio/src/lib.rs
@@ -7,12 +7,12 @@
 //!  * Server: Make a tree handle that stream of incoming messages - see `tree::ATreeServer`
 //!  * Server: Add asynchronous methods to the tree - in case you cannot reply right away,
 //!    you can return a future that will reply when that future resolves - see `tree::AFactory::amethod`
-//! 
+//!
 //! For examples to get you started, see the examples directory and the Readme.
 
 extern crate dbus;
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate mio;
 
 #[macro_use]


### PR DESCRIPTION
Fixes #138.

It uses `current_thread::Runtime` because `ADriver` is `!Send`.