### PR TITLE
dbus: Implement reborrow for cstring wrappers

### DIFF
--- a/dbus/src/strings.rs
+++ b/dbus/src/strings.rs
@@ -2,7 +2,7 @@
 
 use std::{str, fmt, ops, default, hash};
 use std::ffi::{CStr, CString};
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 use std::os::raw::c_char;
 
 #[cfg(not(feature = "no-string-validation"))]
@@ -93,6 +93,12 @@ impl<'m> From<Cow<'m, str>> for $t<'m> {
             Cow::Borrowed(z) => z.into(),
             Cow::Owned(z) => z.into(),
         }
+    }
+}
+
+impl<'inner, 'm: 'inner> From<&'m $t<'inner>> for $t<'m> {
+    fn from(borrow: &'m $t<'inner>) -> $t<'m> {
+        $t(Cow::Borrowed(borrow.0.borrow()))
     }
 }
 

--- a/dbus/src/strings.rs
+++ b/dbus/src/strings.rs
@@ -191,6 +191,20 @@ fn some_path() {
 }
 
 #[test]
+fn reborrow_path() {
+    let p1 = Path::from("/valid");
+    let p2 = p1.clone();
+    {
+        let p2_borrow: &Path = &p2;
+        let p3 = Path::from(p2_borrow);
+        // Check path created from borrow
+        assert_eq!(p2, p3);
+    }
+    // Check path that was previously borrowed
+    assert_eq!(p1, p2);
+}
+
+#[test]
 fn make_sig() {
     assert_eq!(&*Signature::make::<(&str, u8)>(), "(sy)");
 }


### PR DESCRIPTION
This is my attempt at allowing references to `Path`s to be passed to `Connection::with_path`. I believe that with this solution it is similar to doing the following, but with safe code:

```
let borrowed_path = unsafe { Path::from_slice_unchecked(original_path.as_bytes()) };
```