### PR TITLE
Rework appending of value types in iter_append()

### DIFF
--- a/dbus/src/message.rs
+++ b/dbus/src/message.rs
@@ -400,10 +400,10 @@ impl MessageItem {
         v
     }
 
-    fn iter_append_basic(&self, i: &mut ffi::DBusMessageIter, v: i64) {
+    fn iter_append_basic<T>(&self, i: &mut ffi::DBusMessageIter, v: T) {
         let t = self.array_type();
+        let p = &v as *const _ as *const c_void;
         unsafe {
-            let p: *const c_void = mem::transmute(&v);
             ffi::dbus_message_iter_append_basic(i, t as c_int, p);
         }
     }
@@ -415,15 +415,15 @@ impl MessageItem {
                 let p = mem::transmute(&c);
                 ffi::dbus_message_iter_append_basic(i, ffi::DBUS_TYPE_STRING, p);
             },
-            &MessageItem::Bool(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::Byte(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::Int16(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::Int32(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::Int64(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::UInt16(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::UInt32(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::UInt64(b) => self.iter_append_basic(i, b as i64),
-            &MessageItem::UnixFd(ref b) => self.iter_append_basic(i, b.as_raw_fd() as i64),
+            &MessageItem::Bool(b) => self.iter_append_basic(i, b),
+            &MessageItem::Byte(b) => self.iter_append_basic(i, b),
+            &MessageItem::Int16(b) => self.iter_append_basic(i, b),
+            &MessageItem::Int32(b) => self.iter_append_basic(i, b),
+            &MessageItem::Int64(b) => self.iter_append_basic(i, b),
+            &MessageItem::UInt16(b) => self.iter_append_basic(i, b),
+            &MessageItem::UInt32(b) => self.iter_append_basic(i, b),
+            &MessageItem::UInt64(b) => self.iter_append_basic(i, b),
+            &MessageItem::UnixFd(ref b) => self.iter_append_basic(i, b.as_raw_fd()),
             &MessageItem::Double(b) => iter_append_f64(i, b),
             &MessageItem::Array(ref a) => iter_append_array(i, &a.v, a.element_signature()),
             &MessageItem::Struct(ref v) => iter_append_struct(i, &**v),


### PR DESCRIPTION
iter_append_basic() doesn't quite work right on big-endian machines. It
results in the high bits of the i64 being parsed instead of the lower
bits. There's no elegant way to fix this (that I can see) due to the
differing widths of values, so open-code each value type instead of using
a helper function.

Call values v instead of b.

Instead of using mem::transmute(), use two casts: one to *const ptr of
<type>, and then one from that to *const c_void to match ffi function
signature.

Also do UnixFd and Double in this manner, allowing iter_append_basic() and
iter_append_f64() helper functions to be removed.

This also may fix an overflow issue in converting unsigned values to
their signed counterparts.

fixes #158

Signed-off-by: Andy Grover <agrover@redhat.com>