### PR TITLE
Big endian args fix

### DIFF
--- a/dbus/src/arg/basic_impl.rs
+++ b/dbus/src/arg/basic_impl.rs
@@ -16,10 +16,54 @@ fn arg_append_basic<T>(i: *mut ffi::DBusMessageIter, arg_type: ArgType, v: T) {
 
 fn arg_get_basic(i: *mut ffi::DBusMessageIter, arg_type: ArgType) -> Option<i64> {
     let mut c = 0i64;
+
     unsafe {
         if ffi::dbus_message_iter_get_arg_type(i) != arg_type as c_int { return None };
-        ffi::dbus_message_iter_get_basic(i, &mut c as *mut _ as *mut c_void);
     }
+
+    match arg_type {
+        ArgType::Byte => {
+        let mut t = 0u8;
+            unsafe {
+                ffi::dbus_message_iter_get_basic(i, &mut t as *mut _ as *mut c_void);
+            }
+            c = t as i64;
+        },
+        ArgType::Int16 => {
+            let mut t = 0i16;
+            unsafe {
+                ffi::dbus_message_iter_get_basic(i, &mut t as *mut _ as *mut c_void);
+            }
+            c = t as i64;
+        },
+        ArgType::UInt16 => {
+            let mut t = 0u16;
+            unsafe {
+                ffi::dbus_message_iter_get_basic(i, &mut t as *mut _ as *mut c_void);
+            }
+            c = t as i64;
+        },
+        ArgType::Int32 => {
+            let mut t = 0i32;
+            unsafe {
+                ffi::dbus_message_iter_get_basic(i, &mut t as *mut _ as *mut c_void);
+            }
+            c = t as i64;
+        },
+        ArgType::UInt32 => {
+            let mut t = 0u32;
+            unsafe {
+                ffi::dbus_message_iter_get_basic(i, &mut t as *mut _ as *mut c_void);
+            }
+            c = t as i64;
+        },
+        _ => {
+            unsafe {
+                ffi::dbus_message_iter_get_basic(i, &mut c as *mut _ as *mut c_void);
+            }
+        }
+    }
+
     Some(c)
 }
 

--- a/dbus/src/arg/basic_impl.rs
+++ b/dbus/src/arg/basic_impl.rs
@@ -6,7 +6,8 @@ use std::{ptr, any};
 use std::ffi::CStr;
 use std::os::raw::{c_void, c_char, c_int};
 
-fn arg_append_basic(i: *mut ffi::DBusMessageIter, arg_type: ArgType, v: i64) {
+
+fn arg_append_basic<T>(i: *mut ffi::DBusMessageIter, arg_type: ArgType, v: T) {
     let p = &v as *const _ as *const c_void;
     unsafe {
         check("dbus_message_iter_append_basic", ffi::dbus_message_iter_append_basic(i, arg_type as c_int, p));
@@ -68,7 +69,7 @@ impl Arg for $t {
 }
 
 impl Append for $t {
-    fn append(self, i: &mut IterAppend) { arg_append_basic(&mut i.0, ArgType::$s, self as i64) }
+    fn append(self, i: &mut IterAppend) { arg_append_basic(&mut i.0, ArgType::$s, self) }
 }
 
 impl<'a> Get<'a> for $t {
@@ -81,7 +82,7 @@ impl RefArg for $t {
     #[inline]
     fn signature(&self) -> Signature<'static> { unsafe { Signature::from_slice_unchecked($f) } }
     #[inline]
-    fn append(&self, i: &mut IterAppend) { arg_append_basic(&mut i.0, ArgType::$s, *self as i64) }
+    fn append(&self, i: &mut IterAppend) { arg_append_basic(&mut i.0, ArgType::$s, *self) }
     #[inline]
     fn as_any(&self) -> &any::Any { self }
     #[inline]
@@ -240,7 +241,7 @@ impl Arg for OwnedFd {
 impl Append for OwnedFd {
     fn append(self, i: &mut IterAppend) {
         use std::os::unix::io::AsRawFd;
-        arg_append_basic(&mut i.0, ArgType::UnixFd, self.as_raw_fd() as i64)
+        arg_append_basic(&mut i.0, ArgType::UnixFd, self.as_raw_fd())
     }
 }
 impl DictKey for OwnedFd {}


### PR DESCRIPTION
These changes were tested with: https://github.com/tasleson/misc-tools/tree/master/dbus_values on x86_64 and s390x.  The changes for `arg_get_basic` is a non-elegant solution.  Maybe someone else can find a better way of handling it.  I know of no way to have a return type be generic except for returning an enum, but that still wouldn't change how `arg_get_basic`is implemented internally.