### PR TITLE
dbus-tokio: return a plain Future on method call

### DIFF
--- a/dbus-tokio/examples/tokio_client.rs
+++ b/dbus-tokio/examples/tokio_client.rs
@@ -46,7 +46,7 @@ fn main() {
         //TODO: try to handle error when calling on "/"
         let m = Message::new_method_call("com.example.dbustest", "/hello", "com.example.dbustest", "Hello")
             .unwrap().append1(500u32);
-        aconn.method_call(m).unwrap().then(|reply| {
+        aconn.method_call(m).then(|reply| {
             let m = reply.unwrap();
             let msg: &str = m.get1().unwrap();
             println!("{}", msg);

--- a/dbus-tokio/src/lib.rs
+++ b/dbus-tokio/src/lib.rs
@@ -22,4 +22,4 @@ pub mod tree;
 
 mod adriver;
 
-pub use adriver::{AConnection, AMessageStream, AMethodCall};
+pub use adriver::{AConnection, AMessageStream};


### PR DESCRIPTION
This hides the internal details of `method_call` helper struct, returning
a plain `impl Future` instead and removing the need for the additional
`Result` wrapper.