### PR TITLE
futures: Don't assume local path to thin_main_loop crate

### DIFF
--- a/dbus-futures/Cargo.toml
+++ b/dbus-futures/Cargo.toml
@@ -9,8 +9,8 @@ futures-preview = { version = "0.3.0-alpha.12" }
 dbus = { path = "../dbus" }
 
 [dependencies.thin_main_loop]
-# git = "https://github.com/diwic/thin_main_loop.git"
-path = "../../thin_main_loop"
+git = "https://github.com/diwic/thin_main_loop.git"
+#path = "../../thin_main_loop"
 features = ["futures","glib"]
 optional = true
 


### PR DESCRIPTION
Not everyone will have `thin_main_loop` checked out and it will certainly fail when trying to install `dbus-codegen-rust` through `cargo install`:

```
$ cargo install --force --git https://github.com/diwic/dbus-rs.git  --bin dbus-codegen-rust --no-default-features
    Updating git repository `https://github.com/diwic/dbus-rs.git`
error: Could not find `Cargo.toml` in `/home/zeenix/.cargo/git/checkouts/dbus-rs-295c8703110e4ae3/thin_main_loop`
```