### PR TITLE
tokio_dbus: add compatibility with Actix

### DIFF
--- a/dbus-tokio/Cargo.toml
+++ b/dbus-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["David Henningsson <diwic@ubuntu.com>"]
 name = "dbus-tokio"
-version = "0.3.0"
+version = "0.4.0"
 
 description = "Makes it possible to use Tokio with D-Bus, which is a bus commonly used on Linux for inter-process communication."
 repository = "https://github.com/diwic/dbus-rs"

--- a/dbus-tokio/examples/tokio_client.rs
+++ b/dbus-tokio/examples/tokio_client.rs
@@ -7,19 +7,19 @@
 
 extern crate dbus;
 extern crate dbus_tokio;
+extern crate futures;
 extern crate tokio;
 extern crate tokio_timer;
-extern crate futures;
 
 use dbus::*;
 
-use std::rc::Rc;
-use tokio::reactor::Handle;
-use tokio::runtime::current_thread::Runtime;
-use tokio_timer::{clock, Interval};
-use std::time::Duration;
-use futures::{Stream, Future};
 use dbus_tokio::AConnection;
+use futures::{Future, Stream};
+use std::rc::Rc;
+use std::time::Duration;
+use tokio::reactor::Handle;
+use tokio::runtime::current_thread;
+use tokio_timer::{clock, Interval};
 
 fn main() {
     // Let's start by starting up a connection to the session bus. We do not register a name
@@ -28,48 +28,65 @@ fn main() {
 
     // To receive D-Bus signals we need to add match that defines which signals should be forwarded
     // to our application.
-    c.add_match("type=signal,sender=com.example.dbustest,member=HelloHappened").unwrap();
+    c.add_match("type=signal,sender=com.example.dbustest,member=HelloHappened")
+        .unwrap();
 
-    // Create Tokio event loop along with asynchronous connection object
-    let mut rt = Runtime::new().unwrap();
-    let aconn = AConnection::new(c.clone(), Handle::current(), &mut rt).unwrap();
+    // Create asynchronous connection object
+    let f = AConnection::new(c.clone(), Handle::default())
+        .map_err(|_| ())
+        .and_then(|aconn| {
+            let aconn = Rc::new(aconn);
 
-    // Create interval - a Stream that will fire an event periodically
-    let interval = Interval::new(clock::now(), Duration::from_secs(2));
+            // Create interval - a Stream that will fire an event periodically
+            let interval = Interval::new(clock::now(), Duration::from_secs(2));
 
-    // Handle timer errors. Additionally this erases error type from Stream signature.
-    let interval = interval.map_err(|e| panic!("TimerError: {}", e) );
+            // Handle timer errors. Additionally this erases error type from Stream signature.
+            let interval = interval.map_err(|e| panic!("TimerError: {}", e));
 
-    // Create a future calling D-Bus method each time the interval generates a tick
-    let calls = interval.for_each(|_| {
-        println!("Calling Hello...");
-        //TODO: try to handle error when calling on "/"
-        let m = Message::new_method_call("com.example.dbustest", "/hello", "com.example.dbustest", "Hello")
-            .unwrap().append1(500u32);
-        aconn.method_call(m).unwrap().then(|reply| {
-            let m = reply.unwrap();
-            let msg: &str = m.get1().unwrap();
-            println!("{}", msg);
-            Ok(())
-        })
-    });
+            // Create a future calling D-Bus method each time the interval generates a tick
+            let clone = Rc::clone(&aconn);
+            let calls: Box<dyn Future<Item = (), Error = ()>> =
+                Box::new(interval.for_each(move |_| {
+                    println!("Calling Hello...");
+                    //TODO: try to handle error when calling on "/"
+                    let m = Message::new_method_call(
+                        "com.example.dbustest",
+                        "/hello",
+                        "com.example.dbustest",
+                        "Hello",
+                    )
+                    .unwrap()
+                    .append1(500u32);
+                    let aconn = Rc::clone(&clone);
+                    aconn.method_call(m).unwrap().then(|reply| {
+                        let m = reply.unwrap();
+                        let msg: &str = m.get1().unwrap();
+                        println!("Received reply: {}", msg);
+                        Ok(())
+                    })
+                }));
 
-    // Create stream of all incoming D-Bus messages. On top of the messages stream create future,
-    // running forever, handling all incoming messages
-    let messages = aconn.messages().unwrap();
-    let signals = messages.for_each(|m| {
-        let headers = m.headers();
-        let member = headers.3.unwrap();
-        if member == "HelloHappened" {
-            let arg1 : &str = m.get1().unwrap();
-            println!("Hello from {} happened on the bus!", arg1)
-        } else {
-            println!("Unprocessed message: {:?}", m)
-        }
-        Ok(())
-    });
+            // Create stream of all incoming D-Bus messages. On top of the messages stream create future,
+            // running forever, handling all incoming messages
+            let clone = Rc::clone(&aconn);
+            let messages = clone.messages().unwrap();
+            let signals: Box<dyn Future<Item = (), Error = ()>> =
+                Box::new(messages.for_each(|m| {
+                    let headers = m.headers();
+                    let member = headers.3.unwrap();
+                    if member == "HelloHappened" {
+                        let arg1: &str = m.get1().unwrap();
+                        println!("Hello from {} happened on the bus!", arg1)
+                    } else {
+                        println!("Unprocessed message: {:?}", m)
+                    }
+                    Ok(())
+                }));
 
-    // Simultaneously run signal handling and method calling
-    rt.block_on(signals.join(calls)).unwrap();
+            // Simultaneously run signal handling and method calling
+            futures::future::join_all(vec![signals, calls])
+        });
+
+    // Actually run the future
+    current_thread::block_on_all(f).unwrap();
 }
-

--- a/dbus-tokio/src/adriver.rs
+++ b/dbus-tokio/src/adriver.rs
@@ -1,17 +1,18 @@
-use mio::{self, unix, Ready};
+use dbus::{ConnMsgs, Connection, Error as DBusError, Message, MessageType, Watch, WatchEvent};
+use futures::sync::{mpsc, oneshot};
+use futures::{future, Async, Future, Poll, Stream};
 use mio::unix::UnixReady;
-use std::io;
-use dbus::{Connection, ConnMsgs, Watch, WatchEvent, Message, MessageType, Error as DBusError};
-use futures::{Async, Future, Stream, Poll};
-use futures::sync::{oneshot, mpsc};
-use tokio::reactor::Handle as CoreHandle;
-use tokio::reactor::PollEvented2;
-use tokio::runtime::current_thread::Runtime;
-use std::rc::Rc;
-use std::os::raw::c_uint;
+use mio::{self, unix, Ready};
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::error::Error as _;
+use std::io;
+use std::os::raw::c_uint;
 use std::os::unix::io::RawFd;
+use std::rc::Rc;
+use tokio::reactor::Handle as CoreHandle;
+use tokio::reactor::PollEvented2;
+use tokio::runtime::current_thread;
 
 type MCallMap = Rc<RefCell<HashMap<u32, oneshot::Sender<Message>>>>;
 
@@ -30,36 +31,53 @@ pub struct AConnection {
 }
 
 impl AConnection {
-    /// Create an AConnection, which spawns a task on the core.
+    /// Returns a future which creates an AConnection, which spawns a task on the current thread.
     ///
     /// The task handles incoming messages, and continues to do so until the
-    /// AConnection is dropped.
-    pub fn new(c: Rc<Connection>, h: CoreHandle, e: &mut Runtime) -> io::Result<AConnection> {
-        let (tx, rx) = oneshot::channel();
-        let map: MCallMap = Default::default();
-        let istream: MStream = Default::default();
-        let mut d = ADriver {
-            conn: c.clone(),
-            fds: HashMap::new(),
-            core: h.clone(),
-            quit: rx,
-            callmap: map.clone(),
-            msgstream: istream.clone(),
-        };
-        let i = AConnection {
-            conn: c,
-            quit: Some(Rc::new(tx)),
-            callmap: map,
-            msgstream: istream,
-        };
-        i.conn.set_watch_callback(Box::new(|_| unimplemented!("Watch handling is very rare and not implemented yet")));
-        for w in i.conn.watch_fds() { d.modify_watch(w, false)?; }
-        e.spawn(Box::new(d));
-        Ok(i)
+    /// AConnection and all references to it (e.g. in unfinished futures) are dropped.
+    pub fn new(
+        c: Rc<Connection>,
+        h: CoreHandle,
+    ) -> impl Future<Item = AConnection, Error = DBusError> {
+        future::lazy(move || {
+            let (tx, rx) = oneshot::channel();
+            let map: MCallMap = Default::default();
+            let istream: MStream = Default::default();
+            let mut d = ADriver {
+                conn: c.clone(),
+                fds: HashMap::new(),
+                core: h.clone(),
+                quit: rx,
+                callmap: map.clone(),
+                msgstream: istream.clone(),
+            };
+            let i = AConnection {
+                conn: c,
+                quit: Some(Rc::new(tx)),
+                callmap: map,
+                msgstream: istream,
+            };
+            i.conn.set_watch_callback(Box::new(|_| {
+                unimplemented!("Watch handling is very rare and not implemented yet")
+            }));
+            for w in i.conn.watch_fds() {
+                // If any of these fail, we have failed to create an ADriver
+                if let Err(e) = d.modify_watch(w, false) {
+                    return futures::future::err(DBusError::new_custom(
+                        "org.freedesktop.DBus.Error.ModifyWatchError",
+                        e.description(),
+                    ));
+                }
+            }
+            // this MUST be run inside a core.run method i.e. when the future is executed
+            current_thread::spawn(Box::new(d));
+            future::ok(i)
+        })
     }
 
     /// Sends a method call message, and returns a Future for the method return.
-    pub fn method_call(&self, m: Message) -> Result<AMethodCall, &'static str> {
+    /// Must be called on an `RC` so that the future can prevent the connection from being closed.
+    pub fn method_call(self: Rc<Self>, m: Message) -> Result<AMethodCall, &'static str> {
         let serial = self.conn.send(m).map_err(|_| "D-Bus send error")?;
         let (tx, rx) = oneshot::channel();
         let mut map = self.callmap.borrow_mut();
@@ -67,7 +85,13 @@ impl AConnection {
             return Err("Duplicate serial on send");
         }
         map.insert(serial, tx);
-        let mc = AMethodCall { serial, callmap: self.callmap.clone(), inner: rx };
+        let mc = AMethodCall {
+            connection: Rc::clone(&self),
+            serial,
+            callmap: self.callmap.clone(),
+            inner: rx,
+        };
+        println!("created a method call");
         Ok(mc)
     }
 
@@ -77,10 +101,16 @@ impl AConnection {
     /// fail with an error if you try. Drop the first stream if you need to create a second one.
     pub fn messages(&self) -> Result<AMessageStream, &'static str> {
         let mut i = self.msgstream.borrow_mut();
-        if i.is_some() { return Err("Another instance of AMessageStream already exists"); }
+        if i.is_some() {
+            return Err("Another instance of AMessageStream already exists");
+        }
         let (tx, rx) = mpsc::unbounded();
         *i = Some(tx);
-        Ok(AMessageStream { inner: rx, stream: self.msgstream.clone(), quit: self.quit.as_ref().map(|q| q.clone()) })
+        Ok(AMessageStream {
+            inner: rx,
+            stream: self.msgstream.clone(),
+            quit: self.quit.as_ref().map(|q| q.clone()),
+        })
     }
 }
 
@@ -112,19 +142,22 @@ impl ADriver {
         if !w.readable() && !w.writable() {
             self.fds.remove(&w.fd());
         } else {
-
             if let Some(evented) = self.fds.get(&w.fd()) {
                 let ww = evented.get_ref().0;
                 if ww.readable() == w.readable() && ww.writable() == w.writable() {
-                    return Ok(())
+                    return Ok(());
                 };
             }
             self.fds.remove(&w.fd());
 
             let z = PollEvented2::new_with_handle(AWatch(w), &self.core)?;
 
-            if poll_now && z.get_ref().0.readable() { z.clear_read_ready(Ready::readable())?; };
-            if poll_now && z.get_ref().0.writable() { z.clear_write_ready()?; };
+            if poll_now && z.get_ref().0.readable() {
+                z.clear_read_ready(Ready::readable())?;
+            };
+            if poll_now && z.get_ref().0.writable() {
+                z.clear_write_ready()?;
+            };
 
             self.fds.insert(w.fd(), z);
         }
@@ -132,11 +165,17 @@ impl ADriver {
     }
 
     fn send_stream(&self, m: Message) {
-        self.msgstream.borrow().as_ref().map(|z| { z.unbounded_send(m).unwrap() });
+        self.msgstream
+            .borrow()
+            .as_ref()
+            .map(|z| z.unbounded_send(m).unwrap());
     }
 
     fn handle_msgs(&mut self) {
-        let msgs = ConnMsgs { conn: &*self.conn, timeout_ms: None };
+        let msgs = ConnMsgs {
+            conn: &*self.conn,
+            timeout_ms: None,
+        };
         for m in msgs {
             debug!("handle_msgs: {:?}", m);
             if m.msg_type() == MessageType::MethodReturn {
@@ -144,9 +183,14 @@ impl ADriver {
                 let serial = m.get_reply_serial().unwrap();
                 let r = map.remove(&serial);
                 debug!("Serial {:?}, found: {:?}", serial, r.is_some());
-                if let Some(r) = r { r.send(m).unwrap(); }
-                else { self.send_stream(m) }
-            } else { self.send_stream(m) }
+                if let Some(r) = r {
+                    r.send(m).unwrap();
+                } else {
+                    self.send_stream(m)
+                }
+            } else {
+                self.send_stream(m)
+            }
         }
     }
 }
@@ -157,22 +201,35 @@ impl Future for ADriver {
 
     fn poll(&mut self) -> Result<Async<()>, ()> {
         let q = self.quit.poll();
-        if q != Ok(Async::NotReady) { return Ok(Async::Ready(())); }
+        if q != Ok(Async::NotReady) {
+            return Ok(Async::Ready(()));
+        }
 
         for w in self.fds.values() {
             let mut mask = UnixReady::hup() | UnixReady::error();
-            if w.get_ref().0.readable() { mask = mask | Ready::readable().into(); }
+            if w.get_ref().0.readable() {
+                mask = mask | Ready::readable().into();
+            }
             //if w.get_ref().0.writable() { mask = mask | Ready::writable().into(); }
             let prr = w.poll_read_ready(*mask).map_err(|_| ())?;
-            debug!("D-Bus i/o poll read ready: {:?} is {:?}", w.get_ref().0.fd(), prr);
+            debug!(
+                "D-Bus i/o poll read ready: {:?} is {:?}",
+                w.get_ref().0.fd(),
+                prr
+            );
             let pwr = w.poll_write_ready().map_err(|_| ())?;
-            debug!("D-Bus i/o poll write ready: {:?} is {:?}", w.get_ref().0.fd(), pwr);
+            debug!(
+                "D-Bus i/o poll write ready: {:?} is {:?}",
+                w.get_ref().0.fd(),
+                pwr
+            );
             let ur = if let Async::Ready(t) = prr {
-                UnixReady::from(t) | if let Async::Ready(wt) = pwr {
-                    UnixReady::from(wt)
-                } else {
-                    Ready::empty().into()
-                }
+                UnixReady::from(t)
+                    | if let Async::Ready(wt) = pwr {
+                        UnixReady::from(wt)
+                    } else {
+                        Ready::empty().into()
+                    }
             } else {
                 if let Async::Ready(wt) = pwr {
                     UnixReady::from(wt)
@@ -180,16 +237,32 @@ impl Future for ADriver {
                     continue;
                 }
             };
-            let flags =
-                if ur.is_readable() { WatchEvent::Readable as c_uint } else { 0 } +
-                if ur.is_writable() { WatchEvent::Writable as c_uint } else { 0 } +
-                if ur.is_hup() { WatchEvent::Hangup as c_uint } else { 0 } +
-                if ur.is_error() { WatchEvent::Error as c_uint } else { 0 };
+            let flags = if ur.is_readable() {
+                WatchEvent::Readable as c_uint
+            } else {
+                0
+            } + if ur.is_writable() {
+                WatchEvent::Writable as c_uint
+            } else {
+                0
+            } + if ur.is_hup() {
+                WatchEvent::Hangup as c_uint
+            } else {
+                0
+            } + if ur.is_error() {
+                WatchEvent::Error as c_uint
+            } else {
+                0
+            };
             debug!("D-Bus i/o unix ready: {:?} is {:?}", w.get_ref().0.fd(), ur);
             self.conn.watch_handle(w.get_ref().0.fd(), flags);
-            if ur.is_readable() { w.clear_read_ready(Ready::readable()).map_err(|_| ())?; };
-            if ur.is_writable() { w.clear_write_ready().map_err(|_| ())?; };
-        };
+            if ur.is_readable() {
+                w.clear_read_ready(Ready::readable()).map_err(|_| ())?;
+            };
+            if ur.is_writable() {
+                w.clear_write_ready().map_err(|_| ())?;
+            };
+        }
         self.handle_msgs();
         Ok(Async::NotReady)
     }
@@ -199,27 +272,37 @@ impl Future for ADriver {
 struct AWatch(Watch);
 
 impl mio::Evented for AWatch {
-    fn register(&self,
-                poll: &mio::Poll,
-                token: mio::Token,
-                mut interest: mio::Ready,
-                mut opts: mio::PollOpt) -> io::Result<()>
-    {
-        if !self.0.readable() { interest.remove(mio::Ready::readable()) };
-        if !self.0.writable() { interest.remove(mio::Ready::writable()) };
+    fn register(
+        &self,
+        poll: &mio::Poll,
+        token: mio::Token,
+        mut interest: mio::Ready,
+        mut opts: mio::PollOpt,
+    ) -> io::Result<()> {
+        if !self.0.readable() {
+            interest.remove(mio::Ready::readable())
+        };
+        if !self.0.writable() {
+            interest.remove(mio::Ready::writable())
+        };
         opts.remove(mio::PollOpt::edge());
         opts.insert(mio::PollOpt::level());
         unix::EventedFd(&self.0.fd()).register(poll, token, interest, opts)
     }
 
-    fn reregister(&self,
-                  poll: &mio::Poll,
-                  token: mio::Token,
-                  mut interest: mio::Ready,
-                  mut opts: mio::PollOpt) -> io::Result<()>
-    {
-        if !self.0.readable() { interest.remove(mio::Ready::readable()) };
-        if !self.0.writable() { interest.remove(mio::Ready::writable()) };
+    fn reregister(
+        &self,
+        poll: &mio::Poll,
+        token: mio::Token,
+        mut interest: mio::Ready,
+        mut opts: mio::PollOpt,
+    ) -> io::Result<()> {
+        if !self.0.readable() {
+            interest.remove(mio::Ready::readable())
+        };
+        if !self.0.writable() {
+            interest.remove(mio::Ready::writable())
+        };
         opts.remove(mio::PollOpt::edge());
         opts.insert(mio::PollOpt::level());
         unix::EventedFd(&self.0.fd()).reregister(poll, token, interest, opts)
@@ -233,6 +316,8 @@ impl mio::Evented for AWatch {
 #[derive(Debug)]
 /// A Future that resolves when a method call is replied to.
 pub struct AMethodCall {
+    connection: Rc<AConnection>,
+    // the AConnection cannot be deallocated if you want to poll this future
     serial: u32,
     callmap: MCallMap,
     inner: oneshot::Receiver<Message>,
@@ -243,11 +328,15 @@ impl Future for AMethodCall {
     type Error = DBusError;
 
     fn poll(&mut self) -> Result<Async<Self::Item>, Self::Error> {
-        let x = self.inner.poll().map_err(|_| DBusError::new_custom("org.freedesktop.DBus.Failed", "Tokio cancelled future"))?;
+        let x = self.inner.poll().map_err(|_| {
+            DBusError::new_custom("org.freedesktop.DBus.Failed", "Tokio cancelled future")
+        })?;
         if let Async::Ready(mut m) = x {
             m.as_result()?;
             Ok(Async::Ready(m))
-        } else { Ok(Async::NotReady) }
+        } else {
+            Ok(Async::NotReady)
+        }
     }
 }
 
@@ -294,11 +383,20 @@ impl Drop for AMessageStream {
 #[test]
 fn aconnection_test() {
     let conn = Rc::new(Connection::get_private(::dbus::BusType::Session).unwrap());
-    let mut rt = Runtime::new().unwrap();
-    let aconn = AConnection::new(conn.clone(), CoreHandle::current(), &mut rt).unwrap();
+    let f = AConnection::new(conn.clone(), CoreHandle::default()).and_then(move |aconn| {
+        let aconn = Rc::new(aconn);
+        let m = ::dbus::Message::new_method_call(
+            "org.freedesktop.DBus",
+            "/",
+            "org.freedesktop.DBus",
+            "ListNames",
+        )
+        .unwrap();
+        let reply_fut = aconn.method_call(m).unwrap();
+        reply_fut
+    });
 
-    let m = ::dbus::Message::new_method_call("org.freedesktop.DBus", "/", "org.freedesktop.DBus", "ListNames").unwrap();
-    let reply = rt.block_on(aconn.method_call(m).unwrap()).unwrap();
+    let reply = current_thread::block_on_all(f).unwrap();
     let z: Vec<&str> = reply.get1().unwrap();
     println!("got reply: {:?}", z);
     assert!(z.iter().any(|v| *v == "org.freedesktop.DBus"));
@@ -307,13 +405,27 @@ fn aconnection_test() {
 #[test]
 fn astream_test() {
     let conn = Rc::new(Connection::get_private(::dbus::BusType::Session).unwrap());
-    let mut rt = Runtime::new().unwrap();
-    let aconn = AConnection::new(conn.clone(), CoreHandle::current(), &mut rt).unwrap();
+    let f = AConnection::new(conn.clone(), CoreHandle::default())
+        .map_err(|_| ())
+        .and_then(|aconn| {
+            let items: AMessageStream = aconn.messages().unwrap();
+            let signals = items.filter_map(|m| {
+                if m.msg_type() == ::dbus::MessageType::Signal {
+                    Some(m)
+                } else {
+                    None
+                }
+            });
 
-    let items: AMessageStream = aconn.messages().unwrap();
-    let signals = items.filter_map(|m| if m.msg_type() == ::dbus::MessageType::Signal { Some(m) } else { None });
-    let firstsig = rt.block_on(signals.into_future()).map(|(x, _)| x).map_err(|(x, _)| x).unwrap();
+            signals
+                .into_future()
+                .map_err(|_| ())
+                // WARNING: you cannot let the stream escape the current future without being dropped or
+                // `current_thread::block_on_all` will block on it and never finish.
+                .map(|(x, _)| x)
+        });
+
+    let firstsig = current_thread::block_on_all(f).unwrap();
     println!("first signal was: {:?}", firstsig);
     assert_eq!(firstsig.unwrap().msg_type(), ::dbus::MessageType::Signal);
 }
-

--- a/dbus-tokio/src/lib.rs
+++ b/dbus-tokio/src/lib.rs
@@ -12,8 +12,8 @@
 
 extern crate dbus;
 extern crate futures;
-extern crate tokio;
 extern crate mio;
+extern crate tokio;
 
 #[macro_use]
 extern crate log;

--- a/dbus-tokio/src/tree.rs
+++ b/dbus-tokio/src/tree.rs
@@ -1,19 +1,18 @@
-/// Async server-side trees
-
-use std::{ops, fmt, mem};
-use dbus::tree::{Factory, Tree, MethodType, DataType, MTFn, Method, MethodInfo, MethodErr};
-use dbus::{Member, Message, Connection};
-use std::marker::PhantomData;
+use dbus::tree::{DataType, Factory, MTFn, Method, MethodErr, MethodInfo, MethodType, Tree};
+use dbus::{Connection, Member, Message};
+use futures::{Async, Future, IntoFuture, Poll, Stream};
 use std::cell::RefCell;
-use futures::{IntoFuture, Future, Poll, Stream, Async};
 use std::ffi::CString;
+use std::marker::PhantomData;
+/// Async server-side trees
+use std::{fmt, mem, ops};
 
 pub trait ADataType: fmt::Debug + Sized + Default {
     type ObjectPath: fmt::Debug;
     type Property: fmt::Debug;
     type Interface: fmt::Debug + Default;
     type Method: fmt::Debug + Default;
-    type Signal: fmt::Debug;    
+    type Signal: fmt::Debug;
 }
 
 #[derive(Debug, Default)]
@@ -21,7 +20,9 @@ pub trait ADataType: fmt::Debug + Sized + Default {
 pub struct ATree<D: ADataType>(RefCell<Option<AMethodResult>>, PhantomData<*const D>);
 
 impl<D: ADataType> ATree<D> {
-    pub fn new() -> Self { Default::default() }
+    pub fn new() -> Self {
+        Default::default()
+    }
     fn push(&self, a: AMethodResult) {
         let mut z = self.0.borrow_mut();
         assert!(z.is_none(), "Same message handled twice");
@@ -50,12 +51,16 @@ impl ADataType for () {
 pub struct AFactory<M: MethodType<D>, D: DataType = ()>(Factory<M, D>);
 
 impl AFactory<MTFn<()>, ()> {
-    pub fn new_afn<D: ADataType>() -> AFactory<MTFn<ATree<D>>, ATree<D>> { AFactory(Factory::new_fn()) }
+    pub fn new_afn<D: ADataType>() -> AFactory<MTFn<ATree<D>>, ATree<D>> {
+        AFactory(Factory::new_fn())
+    }
 }
 
 impl<M: MethodType<D>, D: DataType> ops::Deref for AFactory<M, D> {
     type Target = Factory<M, D>;
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl<D: ADataType> AFactory<MTFn<ATree<D>>, ATree<D>> {
@@ -63,9 +68,17 @@ impl<D: ADataType> AFactory<MTFn<ATree<D>>, ATree<D>> {
     ///
     /// The method handler supplied to amethod returns a future, which resolves into the method result.
     /// See the tokio_server example for some hints on how to use it.
-    pub fn amethod<H, R, T>(&self, t: T, data: D::Method, handler: H) -> Method<MTFn<ATree<D>>, ATree<D>>
-    where H: 'static + Fn(&MethodInfo<MTFn<ATree<D>>, ATree<D>>) -> R, T: Into<Member<'static>>,
-        R: 'static + IntoFuture<Item=Vec<Message>, Error=MethodErr> {
+    pub fn amethod<H, R, T>(
+        &self,
+        t: T,
+        data: D::Method,
+        handler: H,
+    ) -> Method<MTFn<ATree<D>>, ATree<D>>
+    where
+        H: 'static + Fn(&MethodInfo<MTFn<ATree<D>>, ATree<D>>) -> R,
+        T: Into<Member<'static>>,
+        R: 'static + IntoFuture<Item = Vec<Message>, Error = MethodErr>,
+    {
         self.0.method(t, data, move |minfo| {
             let r = handler(minfo);
             minfo.tree.get_data().push(AMethodResult::new(r));
@@ -77,14 +90,19 @@ impl<D: ADataType> AFactory<MTFn<ATree<D>>, ATree<D>> {
 /// A Future method result
 ///
 /// When method results cannot be returned right away, the AMethodResult holds it temporarily
-struct AMethodResult(Box<Future<Item=Vec<Message>, Error=MethodErr>>, Option<Message>);
+struct AMethodResult(
+    Box<Future<Item = Vec<Message>, Error = MethodErr>>,
+    Option<Message>,
+);
 
 impl fmt::Debug for AMethodResult {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "AMethodResult({:?})", self.1) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AMethodResult({:?})", self.1)
+    }
 }
 
 impl AMethodResult {
-    fn new<F: 'static + IntoFuture<Item=Vec<Message>, Error=MethodErr>>(f: F) -> Self {
+    fn new<F: 'static + IntoFuture<Item = Vec<Message>, Error = MethodErr>>(f: F) -> Self {
         AMethodResult(Box::new(f.into_future()), None)
     }
 }
@@ -97,63 +115,83 @@ impl Future for AMethodResult {
     }
 }
 
-
 #[derive(Debug)]
 /// Creates a filter for incoming messages, that handles messages in the tree.
 ///
 /// See the tokio_server example for some hints on how to use it.
-pub struct ATreeServer<C,T,D,S>
-where C: ops::Deref<Target=Connection>,
-      T: ops::Deref<Target=Tree<MTFn<ATree<D>>, ATree<D>>>,
-      D: ADataType {
-   conn: C,
-   tree: T,
-   stream: S,
-   pendingresults: Vec<AMethodResult>,
+pub struct ATreeServer<C, T, D, S>
+where
+    C: ops::Deref<Target = Connection>,
+    T: ops::Deref<Target = Tree<MTFn<ATree<D>>, ATree<D>>>,
+    D: ADataType,
+{
+    conn: C,
+    tree: T,
+    stream: S,
+    pendingresults: Vec<AMethodResult>,
 }
 
-impl<C,T,D,S> ATreeServer<C,T,D,S>
-where C: ops::Deref<Target=Connection>,
-      T: ops::Deref<Target=Tree<MTFn<ATree<D>>, ATree<D>>>,
-      S: Stream<Item=Message, Error=()>,
-      D: ADataType {
+impl<C, T, D, S> ATreeServer<C, T, D, S>
+where
+    C: ops::Deref<Target = Connection>,
+    T: ops::Deref<Target = Tree<MTFn<ATree<D>>, ATree<D>>>,
+    S: Stream<Item = Message, Error = ()>,
+    D: ADataType,
+{
     pub fn new(c: C, t: T, stream: S) -> Self {
-        ATreeServer { conn: c, tree: t, stream: stream, pendingresults: vec![] }
+        ATreeServer {
+            conn: c,
+            tree: t,
+            stream: stream,
+            pendingresults: vec![],
+        }
     }
 
     fn spawn_method_results(&mut self, msg: Message) {
         let v = self.tree.get_data().0.borrow_mut().take();
         if let Some(mut r) = v {
-            if r.1.is_none() { r.1 = Some(msg); };
+            if r.1.is_none() {
+                r.1 = Some(msg);
+            };
             // println!("Pushing {:?}", r);
             self.pendingresults.push(r);
         }
     }
 
     fn check_pending_results(&mut self) {
-        let v = mem::replace(&mut self.pendingresults, vec!());
-        self.pendingresults = v.into_iter().filter_map(|mut mr| {
-            let z = mr.poll();
-            // println!("Polling {:?} returned {:?}", mr, z);
-            match z {
-                Ok(Async::NotReady) => Some(mr),
-                Ok(Async::Ready(t)) => { for msg in t { self.conn.send(msg).expect("D-Bus send error"); }; None },
-                Err(e) => {
-                    let m = mr.1.take().unwrap(); 
-                    let msg = m.error(&e.errorname(), &CString::new(e.description()).unwrap());
-                    self.conn.send(msg).expect("D-Bus send error");
-                    None
+        let v = mem::replace(&mut self.pendingresults, vec![]);
+        self.pendingresults = v
+            .into_iter()
+            .filter_map(|mut mr| {
+                let z = mr.poll();
+                // println!("Polling {:?} returned {:?}", mr, z);
+                match z {
+                    Ok(Async::NotReady) => Some(mr),
+                    Ok(Async::Ready(t)) => {
+                        for msg in t {
+                            self.conn.send(msg).expect("D-Bus send error");
+                        }
+                        None
+                    }
+                    Err(e) => {
+                        let m = mr.1.take().unwrap();
+                        let msg = m.error(&e.errorname(), &CString::new(e.description()).unwrap());
+                        self.conn.send(msg).expect("D-Bus send error");
+                        None
+                    }
                 }
-            }
-        }).collect();
+            })
+            .collect();
     }
 }
 
-impl<C,T,D,S> Stream for ATreeServer<C,T,D,S>
-where C: ops::Deref<Target=Connection>,
-      T: ops::Deref<Target=Tree<MTFn<ATree<D>>, ATree<D>>>,
-      S: Stream<Item=Message, Error=()>,
-      D: ADataType {
+impl<C, T, D, S> Stream for ATreeServer<C, T, D, S>
+where
+    C: ops::Deref<Target = Connection>,
+    T: ops::Deref<Target = Tree<MTFn<ATree<D>>, ATree<D>>>,
+    S: Stream<Item = Message, Error = ()>,
+    D: ADataType,
+{
     type Item = Message;
     type Error = ();
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
@@ -166,11 +204,16 @@ where C: ops::Deref<Target=Connection>,
                 // println!("hh: {:?}", hh);
                 if let Some(v) = hh {
                     self.spawn_method_results(m);
-                    for msg in v { self.conn.send(msg)?; }
-                    // We consumed the message. Poll again
-                } else { return Ok(Async::Ready(Some(m))) }
-            } else { return z }
+                    for msg in v {
+                        self.conn.send(msg)?;
+                    }
+                // We consumed the message. Poll again
+                } else {
+                    return Ok(Async::Ready(Some(m)));
+                }
+            } else {
+                return z;
+            }
         }
     }
 }
-


### PR DESCRIPTION
Hi, I (and my colleagues) are trying to use the async portion of this library (we're happily using the sync version) and the main issue we had was the requirement to hold a `current_thread::Runtime` so that the `ADriver` can be spawned which, as far as I can tell, Actix does not allow.

In this PR I have changed `AConnection::new` to use `current_thread::spawn` instead, allowing compatibility with any runtime that ultimately uses `current_thread::Runtime` but doesn't expose it directly. This unfortunately means that `AConnection::new` now returns a future since `current_thread::spawn` has to be called inside one.

Another possible option would be to make it accept a [TypedExecutor](https://docs.rs/tokio/0.1.21/tokio/executor/trait.TypedExecutor.html) which Actix's `AsyncContext` doesn't _currently_ implement but I don't think it'd be hard to do that separately.

Additionally I had issues with my `AConnection` being dropped while a `AMethodCall` was still active. This caused the future to never complete. To solve this I made `AMethodCall` keep an `Rc<AConnection>` to prevent the drop while it was still being used. I suspect that this means that the `oneshot::channel` mechanism isn't needed anymore since the future can just query the connection directly but didn't spent much time playing with alternatives.

Finally I ran `cargo fmt` more out of habit than anything else and bumped the version (sorry for the diff).

Happy to split this up, discuss alternatives etc. I've run the tests and the examples (together) and they're all successful.

In summary:
1. Remove `current_thread::Runtime` parameter from `AConnection::new`.
2. Prevent `AConnection` from being dropped while an `AMethodCall` exists.
3. cargo fmt & bump version
