### PR TITLE
Default interface example

### DIFF
--- a/dbus/examples/adv_server.rs
+++ b/dbus/examples/adv_server.rs
@@ -70,7 +70,7 @@ fn create_iface(check_complete_s: mpsc::Sender<i32>) -> (Interface<MTFn<TData>, 
             })
             .on_set(|i, m| {
                 let dev: &Arc<Device> = m.path.get_data();
-                let b: bool = try!(i.read());
+                let b: bool = i.read()?;
                 if b && dev.checking.get() {
                     return Err(MethodErr::failed(&"Device currently under check, cannot bring online"))
                 }
@@ -135,6 +135,9 @@ fn create_tree(devices: &[Arc<Device>], iface: &Arc<Interface<MTFn<TData>, TData
         tree = tree.add(f.object_path(dev.path.clone(), dev.clone())
             .introspectable()
             .add(iface.clone())
+            // We also make sure that any messages that don't specify an interface
+            // get sent to our interface
+            .default_interface(iface.get_name().clone())
         );
     }
     tree 
@@ -150,9 +153,9 @@ fn run() -> Result<(), Box<std::error::Error>> {
     let tree = create_tree(&devices, &Arc::new(iface));
 
     // Setup DBus connection
-    let c = try!(Connection::get_private(BusType::Session));
-    try!(c.register_name("com.example.dbus.rs.advancedserverexample", 0));
-    try!(tree.set_registered(&c, true));
+    let c = Connection::get_private(BusType::Session)?;
+    c.register_name("com.example.dbus.rs.advancedserverexample", 0)?;
+    tree.set_registered(&c, true)?;
 
     // ...and serve incoming requests.
     c.add_handler(tree);
@@ -165,7 +168,8 @@ fn run() -> Result<(), Box<std::error::Error>> {
         if let Ok(idx) = check_complete_r.try_recv() {
             let dev = &devices[idx as usize];
             dev.checking.set(false);
-            try!(c.send(sig.msg(&dev.path, &"com.example.dbus.rs.device".into())).map_err(|_| "Sending DBus signal failed"));
+            c.send(sig.msg(&dev.path, &"com.example.dbus.rs.device".into()))
+                .map_err(|_| "Sending DBus signal failed")?;
         }
     }
 }

--- a/dbus/src/tree/objectpath.rs
+++ b/dbus/src/tree/objectpath.rs
@@ -489,6 +489,14 @@ fn test_iter() {
     assert_eq!(paths.len(), 2);
 }
 
+#[test]
+fn test_set_default_interface() {
+    let iface_name: IfaceName<'_> = "com.example.echo".into();
+    let f = super::Factory::new_fn::<()>();
+    let t = f.object_path("/echo", ()).default_interface(iface_name.clone());
+    assert_eq!(t.default_iface, Some(iface_name));
+}
+
 
 #[test]
 fn test_introspection() {

--- a/dbus/src/watch.rs
+++ b/dbus/src/watch.rs
@@ -219,7 +219,8 @@ mod test {
             if let Some(q) = new_fds { fds = q; new_fds = None };
 
             for f in fds.iter_mut() { f.revents = 0 };
-            assert!(unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, 1000) } > 0);
+
+            assert!(unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, 1000) } > 0);
 
             for f in fds.iter().filter(|pfd| pfd.revents != 0) {
                 let m = WatchEvent::from_revents(f.revents);


### PR DESCRIPTION
Hi, as requested I added a test for `default_interface` and also added it to the `adv_server` example - which I was then able to call from python.

The test for `default_interface` isn't _massively_ useful if you have a suggestion for a better one I'd be happy to set that up. As far as I can see the client can't make calls with no interface so we can't test it with the client part of this library.

I also had an issue when compiling the tests:
```
error[E0308]: mismatched types
   --> dbus/src/watch.rs:222:59
    |
222 |             assert!(unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, 1000) } > 0);
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u32, found u64

error: aborting due to previous error
```
Which I think was due to an assumption about pointer size, which I fixed by instead casting to `libc::nfds_t` instead - the type that `libc::poll` is actually expecting.

Is it possible to release a new version including even just this change? I'd like to move away from our dependency pointing to this repo's master (or the specific commit rather) if I can.

And then one final issue running the tests - `test prop::test_get_policykit_version ... FAILED` which fails because there is no system dbus on my mac. Everything else passed though.