### PR TITLE
Migrate deprecated tempdir dep to tempfile

### DIFF
--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2.60"
 libdbus-sys = { path = "../libdbus-sys", version = "0.2" }
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3"
 
 [features]
 no-string-validation = []

--- a/dbus/src/arg/messageitem.rs
+++ b/dbus/src/arg/messageitem.rs
@@ -630,7 +630,7 @@ impl<'a> PropHandler<'a> {
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use crate::{Connection, Message, MessageType, BusType, libc, Path};
     use crate::arg::messageitem::MessageItem;
@@ -646,7 +646,7 @@ mod test {
         let c = Connection::get_private(BusType::Session).unwrap();
         c.register_object_path("/hello").unwrap();
         let mut m = Message::new_method_call(&c.unique_name(), "/hello", "com.example.hello", "Hello").unwrap();
-        let tempdir = tempdir::TempDir::new("dbus-rs-test").unwrap();
+        let tempdir = tempfile::Builder::new().prefix("dbus-rs-test").tempdir().unwrap();
         let mut filename = tempdir.path().to_path_buf();
         filename.push("test");
         println!("Creating file {:?}", filename);

--- a/dbus/src/arg/msgarg.rs
+++ b/dbus/src/arg/msgarg.rs
@@ -307,8 +307,6 @@ argbuilder_impl!(a A str, b B str, c C str, d D str, e E str, f F str, g G str, 
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
-
     use crate::{Connection, ffidisp::ConnectionItem, Message, BusType, Path, Signature};
     use crate::arg::{Array, Variant, Dict, Iter, ArgType, TypeMismatchError, RefArg, cast};
 


### PR DESCRIPTION
The `tempdir` crate has been deprecated by upstream in favor of `tempfile`.
https://github.com/rust-lang-deprecated/tempdir/issues/45