### PR TITLE
Replacing timeout_ms on the std::time::Duration

### DIFF
--- a/dbus-codegen-tests/tests/test1.rs
+++ b/dbus-codegen-tests/tests/test1.rs
@@ -52,7 +52,7 @@ fn test_main() {
         // New way
         {
             let c3 = dbus::blocking::Connection::new_session().unwrap();
-            let p = c3.with_proxy(cname, "/test", 1000);
+            let p = c3.with_proxy(cname, "/test", std::time::Duration::from_millis(1000));
             use policykit_blocking::OrgFreedesktopDBusIntrospectable;
             assert_eq!(p.introspect().unwrap(), "I feel so introspected right now");
         }

--- a/dbus/examples/client.rs
+++ b/dbus/examples/client.rs
@@ -1,6 +1,7 @@
 extern crate dbus;
 
 use dbus::blocking::Connection;
+use std::time::Duration;
 
 fn main() -> Result<(), Box<std::error::Error>> {
     // First open up a connection to the session bus.
@@ -8,7 +9,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
     // Second, create a wrapper struct around the connection that makes it easy
     // to send method calls to a specific destination and path.
-    let proxy = conn.with_proxy("org.freedesktop.DBus", "/", 5000);
+    let proxy = conn.with_proxy("org.freedesktop.DBus", "/", Duration::from_millis(5000));
 
     // Now make the method call. The ListNames method call takes zero input parameters and 
     // one output parameter which is an array of strings.

--- a/dbus/examples/properties.rs
+++ b/dbus/examples/properties.rs
@@ -2,6 +2,7 @@ extern crate dbus;
 
 use dbus::{blocking::Connection, arg};
 use std::collections::HashMap;
+use std::time::Duration;
 
 fn print_refarg(value: &arg::RefArg) {
     // We don't know what type the value is. We'll try a few and fall back to
@@ -15,7 +16,7 @@ fn main() {
     // Connect to server and create a ConnPath. A ConnPath implements several interfaces,
     // in this case we'll use OrgFreedesktopDBusProperties, which allows us to call "get".
     let c = Connection::new_session().unwrap();
-    let p = c.with_proxy("org.mpris.MediaPlayer2.rhythmbox", "/org/mpris/MediaPlayer2", 5000);
+    let p = c.with_proxy("org.mpris.MediaPlayer2.rhythmbox", "/org/mpris/MediaPlayer2", Duration::from_millis(5000));
     use dbus::blocking::stdintf::org_freedesktop_dbus::Properties;
 
     // The Metadata property is a Dict<String, Variant>. 

--- a/dbus/examples/server.rs
+++ b/dbus/examples/server.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use dbus::blocking::Connection;
 use dbus::tree::Factory;
 use std::error::Error;
+use std::time::Duration;
 
 fn main() -> Result<(), Box<Error>> {
     // Let's start by starting up a connection to the session bus and request a name.
@@ -67,5 +68,5 @@ fn main() -> Result<(), Box<Error>> {
     tree.start_receive(c.clone());
 
     // Serve clients forever.
-    loop { c.process(1000)?; }
+    loop { c.process(Duration::from_millis(1000))?; }
 }

--- a/dbus/src/blocking/stdintf.rs
+++ b/dbus/src/blocking/stdintf.rs
@@ -122,7 +122,7 @@ pub (crate) fn request_name<S: blocking::BlockingSender>(s: &S, name: &str, allo
         if allow_replacement { 1 } else { 0 } +
         if replace_existing { 2 } else { 0 } +
         if do_not_queue { 4 } else { 0 };
-    let proxy = crate::blocking::Proxy::new("org.freedesktop.DBus", "/org/freedesktop/DBus", 5000, s);
+    let proxy = crate::blocking::Proxy::new("org.freedesktop.DBus", "/org/freedesktop/DBus", std::time::Duration::from_millis(5000), s);
     use super::org_freedesktop::DBus;
     let r = proxy.request_name(name, flags)?;
     use RequestNameReply::*;
@@ -135,7 +135,7 @@ pub (crate) fn request_name<S: blocking::BlockingSender>(s: &S, name: &str, allo
 pub (crate) fn release_name<S: blocking::BlockingSender>(s: &S, name: &str)
     -> Result<ReleaseNameReply, dbus::Error> {
 
-    let proxy = crate::blocking::Proxy::new("org.freedesktop.DBus", "/org/freedesktop/DBus", 5000, s);
+    let proxy = crate::blocking::Proxy::new("org.freedesktop.DBus", "/org/freedesktop/DBus", std::time::Duration::from_millis(5000), s);
     use super::org_freedesktop::DBus;
     let r = proxy.release_name(name)?;
     use ReleaseNameReply::*;

--- a/dbus/src/ffidisp/connection.rs
+++ b/dbus/src/ffidisp/connection.rs
@@ -3,7 +3,7 @@
 use crate::{Error, ffi, to_c_str, c_str_to_slice, Message, MessageType};
 use crate::ffidisp::ConnPath;
 use std::{fmt, mem, ptr, thread, panic, ops};
-use std::collections::VecDeque;
+use std::{collections::VecDeque, time::Duration};
 use std::cell::{Cell, RefCell};
 use std::os::unix::io::RawFd;
 use std::os::raw::{c_void, c_char, c_int, c_uint};
@@ -475,8 +475,8 @@ impl crate::channel::Sender for Connection {
 }
 
 impl crate::blocking::BlockingSender for Connection {
-    fn send_with_reply_and_block(&self, msg: Message, timeout_ms: i32) -> Result<Message, Error> {
-        Connection::send_with_reply_and_block(self, msg, timeout_ms)
+    fn send_with_reply_and_block(&self, msg: Message, timeout: Duration) -> Result<Message, Error> {
+        Connection::send_with_reply_and_block(self, msg, timeout.as_millis() as i32)
     }
 }
 

--- a/dbus/src/nonblock.rs
+++ b/dbus/src/nonblock.rs
@@ -64,7 +64,7 @@ impl Connection {
     ///
     /// This is usually called from the reactor when there is input on the file descriptor.
     pub fn read_write(&self) -> Result<(), Error> {
-        self.channel.read_write(Some(0)).map_err(|_| Error::new_custom("org.freedesktop.DBus.Error.Failed", "Read/write failed"))
+        self.channel.read_write(Some(Default::default())).map_err(|_| Error::new_custom("org.freedesktop.DBus.Error.Failed", "Read/write failed"))
     }
 
     /// Dispatches all pending messages, without blocking.


### PR DESCRIPTION
Replace only blocking module. ffidisp is a legacy module for easy migration.

Closes: #195