### PR TITLE
[codegen] Take value on --file

### DIFF
--- a/dbus-codegen/src/main.rs
+++ b/dbus-codegen/src/main.rs
@@ -56,7 +56,8 @@ Defaults to 'RefClosure'."))
              .help("Type of client connection. Valid values are: 'blocking', 'nonblock', 'ffidisp'."))
         .arg(clap::Arg::with_name("output").short("o").long("output").takes_value(true).value_name("FILE")
              .help("Write output into the specified file"))
-        .arg(clap::Arg::with_name("file").long("file").required(false).help("D-Bus XML Introspection file"))
+        .arg(clap::Arg::with_name("file").long("file").required(false).takes_value(true).value_name("FILE")
+            .help("D-Bus XML Introspection file"))
         .get_matches();
 
     if matches.is_present("destination") && matches.is_present("file") {


### PR DESCRIPTION
The `dbus-codegen-rust` binary has a `--file` argument that is supposed to read the introspection XML data from a file. It is attempting to process the value for this argument at `dbus-codegen/src/main.rs:74`, however the corresponding `clap::App` is not configured to take or expect a value to be given for this argument.

This PR fixes this, by having the `file` argument of `dbus-codegen-rust` take a value.