### PR TITLE
MatchRule: Add "eavesdrop" bool flag

### DIFF
--- a/dbus/examples/monitor.rs
+++ b/dbus/examples/monitor.rs
@@ -1,0 +1,24 @@
+use dbus::ffidisp::Connection;
+use dbus::message::MatchRule;
+
+// This programs implements the equivalent of running the "dbus-monitor" tool
+fn main() {
+    // First open up a connection to the session bus.
+    let conn = Connection::new_session().expect("D-Bus connection failed");
+
+    // Second create a rule to match messages we want to receive; in this example we add no
+    // further requirements, so all messages will match
+    let mut rule = MatchRule::new();
+    rule.eavesdrop = true; // this lets us eavesdrop on *all* session messages, not just ours
+
+    // Start matching
+    conn.add_match(&rule.match_str()).expect("add_match failed");
+
+    // Loop and print out all messages received as they come.
+    // Some can be quite large, e.g. if they contain embedded images..
+    loop {
+        if let Some(msg) = conn.incoming(5000).next() {
+            println!("{:?}", msg);
+        }
+    }
+}

--- a/dbus/src/message/matchrule.rs
+++ b/dbus/src/message/matchrule.rs
@@ -21,6 +21,8 @@ pub struct MatchRule<'a> {
     pub interface: Option<Interface<'a>>,
     /// Match on message member (signal or method name)
     pub member: Option<Member<'a>>,
+    /// If true, also receive messages not intended for us. Defaults to false.
+    pub eavesdrop: bool,
     _more_fields_may_come: (),
 }
 
@@ -45,6 +47,7 @@ impl<'a> MatchRule<'a> {
         if let Some(ref x) = self.path { v.push((pn, &x)) };
         if let Some(ref x) = self.interface { v.push(("interface", &x)) };
         if let Some(ref x) = self.member { v.push(("member", &x)) };
+        if self.eavesdrop { v.push(("eavesdrop", "true")) };
 
         // For now we don't need to worry about internal quotes in strings as those are not valid names.
         // If we start matching against arguments, we need to worry.
@@ -109,6 +112,7 @@ impl<'a> MatchRule<'a> {
             interface: self.interface.as_ref().map(|x| x.clone().into_static()),
             member: self.member.as_ref().map(|x| x.clone().into_static()),
             path_is_namespace: self.path_is_namespace,
+            eavesdrop: self.eavesdrop,
             _more_fields_may_come: (),
         }
     }


### PR DESCRIPTION
This allows implementing e.g. dbus-monitor in Rust.
See https://stackoverflow.com/questions/11544836/monitoring-dbus-messages-by-python

I could add a simple dbus-monitor implementation to the examples if you like.