### PR TITLE
add option to run the dbus connection processing against a borrowed tree

### DIFF
--- a/dbus/src/blocking.rs
+++ b/dbus/src/blocking.rs
@@ -127,6 +127,11 @@ impl $c {
             Ok(false)
         }
     }
+
+    /// The channel for this connection
+    pub fn channel(&self) -> &Channel {
+        &self.channel
+    }
 }
 
 impl BlockingSender for $c {


### PR DESCRIPTION
this removes the need to move the tree into a filter closure.
By allowing the user to keep ownership of the tree, it allows mutating the tree without having to use `Arc<Mutex<...>>` style tricks.

For an api usage pov, this replaces

```rust
tree.start_receive(&c);
loop { c.process(Duration::from_millis(1000))?; }
```

with

```rust
loop { c.process_with_tree(&tree, Duration::from_millis(1000))?; }
```