### PR TITLE
test: Check for proper processing of large messages

### DIFF
--- a/dbus-tokio/Cargo.toml
+++ b/dbus-tokio/Cargo.toml
@@ -20,6 +20,7 @@ tokio = {version = "0.2.4", features=["time", "macros", "io-driver", "rt-core", 
 
 [dev-dependencies]
 futures = "0.3.1"
+tokio = {version = "0.2.4", features=["time", "macros", "io-driver", "rt-core", "rt-util", "rt-threaded", "stream", "blocking"]}
 # dbus-crossroads = { path = "../dbus-crossroads" }
 
 [badges]


### PR DESCRIPTION
Tests for the issue raised in #254.

Not quite sure about the atomic ordering, but certainly looks similar to the example `Acquire`/`Release` use case.