### PR TITLE
Fix incliding the repo as a Cargo dependency.

### DIFF
--- a/attic/dbus-futures/Cargo.toml
+++ b/attic/dbus-futures/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 futures-preview = { version = "0.3.0-alpha.16" }
-dbus = { path = "../dbus" }
+dbus = { path = "../../dbus" }
 
 [dependencies.thin_main_loop]
 # git = "https://github.com/diwic/thin_main_loop.git"


### PR DESCRIPTION
cargo tries to resolve all the individual crates, and the dbus-futures Cargo.toml didn't get its path updated when it moved into the attic, so it'd look for the dbus crate in attic/dbus. 