### PR TITLE
Make dbus dependency optional in dbus-codegen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
   - cargo update
   - cargo check --all
   - cargo test --all -- --nocapture --color always
+  - cd dbus-codegen && cargo test --all --no-default-features -- --nocapture --color always

--- a/dbus-codegen/Cargo.toml
+++ b/dbus-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbus-codegen"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["David Henningsson <diwic@ubuntu.com>"]
 description = "Binary crate to generate Rust code from XML introspection data"
 license = "Apache-2.0/MIT"
@@ -9,6 +9,9 @@ repository = "https://github.com/diwic/dbus-rs"
 keywords = ["D-Bus", "DBus"]
 readme = "README.md"
 edition = "2018"
+
+[features]
+default = ["dbus"]
 
 [lib]
 path = "src/lib.rs"
@@ -19,8 +22,13 @@ path = "src/main.rs"
 
 [dependencies]
 xml-rs = "0.3"
-dbus = { path = "../dbus", version = "0.8" }
-clap = "2.20"
+dbus = { path = "../dbus", version = "0.8", optional = true }
+structopt = "0.3"
+strum = "0.18"
+strum_macros = "0.18"
+
+[dev-dependencies]
+dbus = { path = "../dbus", version = "0.8" } # Same as above, but not optional
 
 [badges]
 is-it-maintained-open-issues = { repository = "diwic/dbus-rs" }

--- a/dbus-codegen/src/generate.rs
+++ b/dbus-codegen/src/generate.rs
@@ -1001,7 +1001,7 @@ static FROM_DBUS: &'static str = r#"
     #[cfg(feature = "dbus")]
     #[test]
     fn argtype_is_complete() {
-        let mut foreign = dbus::arg::ArgType::iter().map(|e| e as u8).collect::<Vec<_>>();
+        let mut foreign = dbus::arg::ArgType::all().iter().map(|e| *e as u8).collect::<Vec<_>>();
         let mut internal = super::ArgType::iter().map(|e| e as u8).collect::<Vec<_>>();
         foreign.sort_unstable();
         internal.sort_unstable();

--- a/dbus-codegen/src/lib.rs
+++ b/dbus-codegen/src/lib.rs
@@ -1,7 +1,7 @@
-extern crate dbus;
 extern crate xml;
+#[cfg(feature = "dbus")]
+extern crate dbus;
 
 mod generate;
 
-pub use crate::generate::{generate, GenOpts, ServerAccess, ConnectionType};
-
+pub use crate::generate::{generate, ConnectionType, GenOpts, ServerAccess};

--- a/dbus-codegen/src/main.rs
+++ b/dbus-codegen/src/main.rs
@@ -111,13 +111,8 @@ struct Args {
 }
 
 /// This program was previously documented as accepting lowercase strings for enums, so it would be a breaking change
-/// to stop accepting them. If any enum variants are named the same but with different casing this will panic.
+/// to stop accepting them.
 fn lowercase_to_enum<T: IntoEnumIterator + Display>(src: &str) -> T {
-    assert!({
-        let mut lower_names = T::iter().map(|s| s.to_string().to_lowercase()).collect::<Vec<_>>();
-        lower_names.sort_unstable();
-        lower_names.windows(2).all(|w| w[0] != w[1])
-    });
     let src = src.to_lowercase();
     for variant in T::iter() {
         if src == variant.to_string().to_lowercase() {

--- a/dbus-codegen/src/main.rs
+++ b/dbus-codegen/src/main.rs
@@ -1,18 +1,31 @@
 extern crate xml;
+#[cfg(feature = "dbus")]
 extern crate dbus;
-extern crate clap;
+extern crate structopt;
 
 mod generate;
 
+use std::{
+    fmt::Display,
+    path::PathBuf,
+};
+
+use structopt::StructOpt;
+use strum::{IntoEnumIterator, VariantNames};
+use strum_macros::{Display, EnumIter, EnumString, EnumVariantNames};
+
+#[cfg(feature = "dbus")]
 use dbus::ffidisp::Connection;
 
 use crate::generate::{ServerAccess, ConnectionType};
 
+#[cfg(feature = "dbus")]
 // Copy-pasted from the output of this program :-)
 pub trait OrgFreedesktopDBusIntrospectable {
     fn introspect(&self) -> Result<String, ::dbus::Error>;
 }
 
+#[cfg(feature = "dbus")]
 impl<'a, C: ::std::ops::Deref<Target=::dbus::ffidisp::Connection>> OrgFreedesktopDBusIntrospectable for ::dbus::ffidisp::ConnPath<'a, C> {
 
     fn introspect(&self) -> Result<String, ::dbus::Error> {
@@ -25,102 +38,156 @@ impl<'a, C: ::std::ops::Deref<Target=::dbus::ffidisp::Connection>> OrgFreedeskto
     }
 }
 
+#[derive(StructOpt)]
+#[structopt(name = "D-Bus Rust code generator", about = "Generates Rust code from xml introspection data")]
+struct Args {
+    /// If present, connects to the supplied service to get introspection data. Reads from stdin otherwise.
+    #[cfg(feature = "dbus")]
+    #[structopt(short, long, value_name = "BUSNAME")]
+    destination: Option<String>,
+    /// The path to ask for introspection data. (Ignored if destination is not specified.)
+    #[cfg(feature = "dbus")]
+    #[structopt(short, long, default_value = "/", value_name = "PATH")]
+    path: String,
+    /// Comma separated list of filter strings. Only matching interfaces are generated if set.
+    #[structopt(short = "f", long, value_name = "FILTER", use_delimiter = true)]
+    interfaces: Option<Vec<String>>,
+    /// Connects to system bus, if not specified, the session bus will be used. (Ignored if destination is not specified.)
+    #[cfg(feature = "dbus")]
+    #[structopt(short, long = "system-bus")]
+    systembus: bool,
+    /// If present, will try to make variant arguments generic instead of Variant<Box<dyn RefArg>>.
+    /// Experimental, does not work with server methods (other than None).
+    #[structopt(short, long = "generic-variant")]
+    genericvariant: bool,
+    /// Type of server method
+    #[structopt(
+        short,
+        long,
+        value_name = "Fn",
+        default_value = "Fn",
+        parse(from_str = lowercase_to_enum),
+        possible_values = &MethodType::VARIANTS,
+        case_insensitive = true,
+    )]
+    methodtype: MethodType,
+    /// Specifies how to access the type implementing the interface (experimental).
+    #[structopt(
+        short = "a",
+        long,
+        value_name = "RefClosure",
+        default_value = "RefClosure",
+        parse(from_str = lowercase_to_enum),
+        possible_values = &ServerAccess::VARIANTS,
+        case_insensitive = true,
+    )]
+    methodaccess: ServerAccess,
+    /// Name of dbus crate, defaults to 'dbus'.
+    #[structopt(long, value_name = "dbus", default_value = "dbus")]
+    dbuscrate: String,
+    /// If present, skips a specific prefix for interface names, e g 'org.freedesktop.DBus.'.
+    #[structopt(short = "i", long, value_name = "PREFIX")]
+    skipprefix: Option<String>,
+    // /// Generates code to use with futures 0.3 (experimental)
+    // #[structopt(short, long)]
+    // futures: bool,
+    /// Type of client connection.
+    #[structopt(
+        short,
+        long,
+        value_name = "CLIENT",
+        default_value = "Blocking",
+        parse(from_str = lowercase_to_enum),
+        possible_values = &ConnectionType::VARIANTS,
+        case_insensitive = true,
+    )]
+    client: ConnectionType,
+    /// Write output into the specified file
+    #[structopt(short, long, value_name = "FILE")]
+    output: Option<PathBuf>,
+    /// D-Bus XML Introspection file
+    #[structopt(long, value_name = "FILE")]
+    file: Option<PathBuf>,
+}
+
+/// This program was previously documented as accepting lowercase strings for enums, so it would be a breaking change
+/// to stop accepting them. If any enum variants are named the same but with different casing this will panic.
+fn lowercase_to_enum<T: IntoEnumIterator + Display>(src: &str) -> T {
+    assert!({
+        let mut lower_names = T::iter().map(|s| s.to_string().to_lowercase()).collect::<Vec<_>>();
+        lower_names.sort_unstable();
+        lower_names.windows(2).all(|w| w[0] != w[1])
+    });
+    let src = src.to_lowercase();
+    for variant in T::iter() {
+        if src == variant.to_string().to_lowercase() {
+            return variant;
+        }
+    }
+    unreachable!("possible_values from clap will guarantee we never arrive here.")
+}
+
+#[derive(Display, EnumIter, EnumString, EnumVariantNames)]
+enum MethodType {
+    Fn,
+    FnMut,
+    Sync,
+    Generic,
+    Par,
+    None,
+}
 
 // Unwrapping is fine here, this is just a test program.
 
 fn main() {
-    let matches = clap::App::new("D-Bus Rust code generator").about("Generates Rust code from xml introspection data")
-        .arg(clap::Arg::with_name("destination").short("d").long("destination").takes_value(true).value_name("BUSNAME")
-             .help("If present, connects to the supplied service to get introspection data. Reads from stdin otherwise."))
-        .arg(clap::Arg::with_name("path").short("p").long("path").takes_value(true).value_name("PATH")
-             .help("The path to ask for introspection data. Defaults to '/'. (Ignored if destination is not specified.)"))
-        .arg(clap::Arg::with_name("interfaces").short("f").long("interfaces").takes_value(true).value_name("FILTER")
-            .help("Comma separated list of filter strings. Only matching interfaces are generated if set."))
-        .arg(clap::Arg::with_name("systembus").short("s").long("system-bus")
-             .help("Connects to system bus, if not specified, the session bus will be used. (Ignored if destination is not specified.)"))
-        .arg(clap::Arg::with_name("genericvariant").short("g").long("generic-variant")
-             .help("If present, will try to make variant arguments generic instead of Variant<Box<dyn RefArg>>. \
-Experimental, does not work with server methods (other than None)."))
-        .arg(clap::Arg::with_name("methodtype").short("m").long("methodtype").takes_value(true).value_name("Fn")
-             .help("Type of server method; valid values are: 'Fn', 'FnMut', 'Sync', 'Generic', and 'None'. Defaults to 'Fn'."))
-        .arg(clap::Arg::with_name("methodaccess").short("a").long("methodaccess").takes_value(true).value_name("RefClosure")
-             .help("Specifies how to access the type implementing the interface (experimental). Valid values are: 'RefClosure', 'AsRefClosure', 'MethodInfo'. \
-Defaults to 'RefClosure'."))
-        .arg(clap::Arg::with_name("dbuscrate").long("dbuscrate").takes_value(true).value_name("dbus")
-             .help("Name of dbus crate, defaults to 'dbus'."))
-        .arg(clap::Arg::with_name("skipprefix").short("i").long("skipprefix").takes_value(true).value_name("PREFIX")
-             .help("If present, skips a specific prefix for interface names, e g 'org.freedesktop.DBus.'."))
-//        .arg(clap::Arg::with_name("futures").short("f").long("futures")
-//             .help("Generates code to use with futures 0.3 (experimental)"))
-        .arg(clap::Arg::with_name("client").short("c").long("client").takes_value(true).value_name("client")
-             .help("Type of client connection. Valid values are: 'blocking', 'nonblock', 'ffidisp'."))
-        .arg(clap::Arg::with_name("output").short("o").long("output").takes_value(true).value_name("FILE")
-             .help("Write output into the specified file"))
-        .arg(clap::Arg::with_name("file").long("file").required(false).takes_value(true).value_name("FILE")
-            .help("D-Bus XML Introspection file"))
-        .get_matches();
+    let args = Args::from_args();
 
-    if matches.is_present("destination") && matches.is_present("file") {
+    #[cfg(feature = "dbus")]
+    if args.destination.is_some() && args.file.is_some() {
         panic!("Expected either xml file path as argument or destination option. But both are provided.");
     }
+    let mut s = String::new();
+    #[cfg(feature = "dbus")]
+    {
+        if let Some(dest) = args.destination {
+            let c = if args.systembus { Connection::new_system() } else { Connection::new_session() };
+            let c = c.unwrap();
+            let p = c.with_path(dest, args.path, 10000);
+            s = p.introspect().unwrap();
+        }
+    }
+    if s == "" {
+        s = if let Some(file_path) = args.file  {
+            std::fs::read_to_string(&file_path).unwrap()
+        } else {
+            let mut s = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(),&mut s).unwrap();
+            s
+        };
+    }
+    let s = s;
 
-    let s =
-    if let Some(dest) = matches.value_of("destination") {
-        let path = matches.value_of("path").unwrap_or("/");
-        let c = if matches.is_present("systembus") { Connection::new_system() } else { Connection::new_session() };
-        let c = c.unwrap();
-        let p = c.with_path(dest, path, 10000);
-        p.introspect().unwrap()
-    } else if let Some(file_path) = matches.value_of("file")  {
-        std::fs::read_to_string(file_path.to_string()).unwrap()
-    } else {
-        let mut s = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(),&mut s).unwrap();
-        s
+    let (mtype, crhandler) = match args.methodtype {
+        MethodType::Fn => (Some("MTFn"), None),
+        MethodType::FnMut => (Some("MTFnMut"), None),
+        MethodType::Sync => (Some("MTSync"), None),
+        MethodType::Generic => (Some("MethodType"), None),
+        MethodType::Par => (None, Some("Par")),
+        MethodType::None => (None, None),
     };
 
-    let dbuscrate = matches.value_of("dbuscrate").unwrap_or("dbus");
-
-    let mtype = matches.value_of("methodtype").map(|s| s.to_lowercase());
-    let (mtype, crhandler) = match mtype.as_ref().map(|s| &**s) {
-        None | Some("fn") => (Some("MTFn"), None),
-        Some("fnmut") => (Some("MTFnMut"), None),
-        Some("sync") => (Some("MTSync"), None),
-        Some("generic") => (Some("MethodType"), None),
-        Some("par") => (None, Some("Par")),
-        Some("none") => (None, None),
-        _ => panic!("Invalid methodtype specified"),
-    };
-
-    let maccess = matches.value_of("methodaccess").map(|s| s.to_lowercase());
-    let maccess = match maccess.as_ref().map(|s| &**s) {
-        None | Some("refclosure") => ServerAccess::RefClosure,
-        Some("asrefclosure") => ServerAccess::AsRefClosure,
-        Some("methodinfo") => ServerAccess::MethodInfo,
-        _ => panic!("Invalid methodaccess specified"),
-    };
-
-    let client = matches.value_of("client").map(|s| s.to_lowercase());
-    let client = match client.as_ref().map(|s| &**s) {
-        None | Some("blocking") => ConnectionType::Blocking,
-        Some("nonblock") => ConnectionType::Nonblock,
-        Some("ffidisp") => ConnectionType::Ffidisp,
-        _ => panic!("Invalid client connection type specified"),
-    };
-
-    let interfaces = matches.value_of("interfaces").map(|s| s.split(",").map(|e| e.trim().to_owned()).collect());
-
-    let opts = generate::GenOpts { methodtype: mtype.map(|x| x.into()), dbuscrate: dbuscrate.into(),
-        skipprefix: matches.value_of("skipprefix").map(|x| x.into()), serveraccess: maccess,
-        genericvariant: matches.is_present("genericvariant"),
+    let opts = generate::GenOpts { methodtype: mtype.map(|x| x.into()), dbuscrate: args.dbuscrate.into(),
+        skipprefix: args.skipprefix,
+        serveraccess: args.methodaccess,
+        genericvariant: args.genericvariant,
         futures: false,
-        connectiontype: client,
+        connectiontype: args.client,
         crhandler: crhandler.map(|x| x.to_string()),
-        interfaces,
+        interfaces: args.interfaces.map(|v| v.into_iter().collect()),
         command_line: std::env::args().skip(1).collect::<Vec<String>>().join(" ")
     };
 
-    let mut h: Box<dyn std::io::Write> = match matches.value_of("output") {
+    let mut h: Box<dyn std::io::Write> = match args.output {
         Some(file_path) => Box::new(std::fs::File::create(file_path)
             .unwrap_or_else(|e| {
                 panic!("Failed to open {}", e);

--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -17,8 +17,6 @@ edition = "2018"
 libc = "0.2.66"
 libdbus-sys = { path = "../libdbus-sys", version = "0.2" }
 futures = { version = "0.3.1", optional = true }
-strum = "0.18"
-strum_macros = "0.18"
 
 [dev-dependencies]
 tempfile = "3"

--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -17,6 +17,8 @@ edition = "2018"
 libc = "0.2.66"
 libdbus-sys = { path = "../libdbus-sys", version = "0.2" }
 futures = { version = "0.3.1", optional = true }
+strum = "0.18"
+strum_macros = "0.18"
 
 [dev-dependencies]
 tempfile = "3"

--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -20,6 +20,8 @@ futures = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
+strum = "0.18"
+strum_macros = "0.18"
 
 [features]
 no-string-validation = []

--- a/dbus/src/arg/mod.rs
+++ b/dbus/src/arg/mod.rs
@@ -75,6 +75,8 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_void, c_int};
 use std::os::unix::io::{RawFd, AsRawFd, FromRawFd, IntoRawFd};
 
+use strum_macros::EnumIter;
+
 fn check(f: &str, i: u32) { if i == 0 { panic!("D-Bus error: '{}' failed", f) }}
 
 fn ffi_iter() -> ffi::DBusMessageIter {
@@ -372,7 +374,7 @@ impl<'a> Iterator for Iter<'a> {
 ///
 /// use this to figure out, e g, which type of argument is at the current position of Iter.
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, EnumIter)]
 pub enum ArgType {
     /// Dicts are Arrays of dict entries, so Dict types will have Array as ArgType.
     Array = ffi::DBUS_TYPE_ARRAY as u8,
@@ -500,4 +502,19 @@ fn test_compile() {
     q.append(Array::new(&[5u8, 6, 7]));
     q.append((8u8, &[9u8, 6, 7][..]));
     q.append(Variant((6u8, 7u8)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn all_arg_types_up_to_date() {
+        let mut actual = ArgType::iter().map(|v| v as u8).collect::<Vec<_>>();
+        let mut presented = ALL_ARG_TYPES.iter().map(|e| e.0 as u8).collect::<Vec<_>>();
+        actual.sort_unstable();
+        presented.sort_unstable();
+        assert_eq!(actual, presented);
+    }
 }

--- a/dbus/src/arg/mod.rs
+++ b/dbus/src/arg/mod.rs
@@ -75,8 +75,6 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_void, c_int};
 use std::os::unix::io::{RawFd, AsRawFd, FromRawFd, IntoRawFd};
 
-use strum_macros::EnumIter;
-
 fn check(f: &str, i: u32) { if i == 0 { panic!("D-Bus error: '{}' failed", f) }}
 
 fn ffi_iter() -> ffi::DBusMessageIter {
@@ -374,7 +372,7 @@ impl<'a> Iterator for Iter<'a> {
 ///
 /// use this to figure out, e g, which type of argument is at the current position of Iter.
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, EnumIter)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ArgType {
     /// Dicts are Arrays of dict entries, so Dict types will have Array as ArgType.
     Array = ffi::DBUS_TYPE_ARRAY as u8,
@@ -502,19 +500,4 @@ fn test_compile() {
     q.append(Array::new(&[5u8, 6, 7]));
     q.append((8u8, &[9u8, 6, 7][..]));
     q.append(Variant((6u8, 7u8)));
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use strum::IntoEnumIterator;
-
-    #[test]
-    fn all_arg_types_up_to_date() {
-        let mut actual = ArgType::iter().map(|v| v as u8).collect::<Vec<_>>();
-        let mut presented = ALL_ARG_TYPES.iter().map(|e| e.0 as u8).collect::<Vec<_>>();
-        actual.sort_unstable();
-        presented.sort_unstable();
-        assert_eq!(actual, presented);
-    }
 }

--- a/dbus/src/arg/mod.rs
+++ b/dbus/src/arg/mod.rs
@@ -373,6 +373,7 @@ impl<'a> Iterator for Iter<'a> {
 /// use this to figure out, e g, which type of argument is at the current position of Iter.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(test, derive(strum_macros::EnumIter))]
 pub enum ArgType {
     /// Dicts are Arrays of dict entries, so Dict types will have Array as ArgType.
     Array = ffi::DBUS_TYPE_ARRAY as u8,
@@ -500,4 +501,19 @@ fn test_compile() {
     q.append(Array::new(&[5u8, 6, 7]));
     q.append((8u8, &[9u8, 6, 7][..]));
     q.append(Variant((6u8, 7u8)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn all_arg_types_up_to_date() {
+        let mut actual = ArgType::iter().map(|v| v as u8).collect::<Vec<_>>();
+        let mut presented = ALL_ARG_TYPES.iter().map(|e| e.0 as u8).collect::<Vec<_>>();
+        actual.sort_unstable();
+        presented.sort_unstable();
+        assert_eq!(actual, presented);
+    }
 }


### PR DESCRIPTION
I expect this might be a controversial patch. Therefore I want to state right from the get go: No hard feelings if you just want to close this PR.

When cross compiling a project using dbus it feels silly to have to depend on host architecture dbus development libraries, and yet that's exactly what a project of mine has to to do. I spotted some ways to remove this dependency from dbus-codegen, but it comes at a few costs.

1. ArgType information is duplicated into dbus-codegen. I don't expect this to present a significant maintenance burden, but I'm ill informed on the topic.
2. ~~Usage as a binary is completely eliminated. Because cargo doesn't have [something like this](https://github.com/rust-lang/rfcs/pull/2887) I'm unable to specify the dbus dependency for just the binary crate usage.~~ One alternative would be stripping out the ability to obtain the dbus introspection xml from a running dbus service, and leaving the binary usage. EDIT: Did this via a cargo feature ~~I'm not sure how much the project gains from that, but then again I'm not a binary user.~~

Yet another option available to us is to separate out the library and binary into separate crates, which would enable us to declare a dbus dependency for just the binary.

Anyways, I'm curious how the project maintainers feel about these options. Thanks for reviewing my PR!