### PR TITLE
codegen: reenable --futures flag

### DIFF
--- a/dbus-codegen/src/main.rs
+++ b/dbus-codegen/src/main.rs
@@ -46,8 +46,8 @@ Defaults to 'RefClosure'."))
              .help("Name of dbus crate, defaults to 'dbus'."))
         .arg(clap::Arg::with_name("skipprefix").short("i").long("skipprefix").takes_value(true).value_name("PREFIX")
              .help("If present, skips a specific prefix for interface names, e g 'org.freedesktop.DBus.'."))
-//        .arg(clap::Arg::with_name("futures").short("f").long("futures")
-//             .help("Generates code to use with futures 0.3 (experimental)"))
+       .arg(clap::Arg::with_name("futures").short("f").long("futures")
+            .help("Generates code to use with futures 0.3 (experimental)"))
         .arg(clap::Arg::with_name("client").short("c").long("client").takes_value(true).value_name("client")
              .help("Type of client connection. Valid values are: 'blocking', 'nonblock', 'ffidisp'."))
         .arg(clap::Arg::with_name("output").short("o").long("output").takes_value(true).value_name("FILE")
@@ -120,7 +120,7 @@ Defaults to 'RefClosure'."))
         skipprefix: matches.value_of("skipprefix").map(|x| x.into()),
         serveraccess: maccess,
         genericvariant: matches.is_present("genericvariant"),
-        futures: false,
+        futures: matches.is_present("futures"),
         connectiontype: client,
         crhandler: crhandler.map(|x| x.to_string()),
         interfaces,


### PR DESCRIPTION
This is part of an effort to produce a non-blocking bluez client library, for use in https://github.com/alsuren/reading-xiaomi-temp/pull/27 . I would really rather not maintain my own bluez library manually, but I'm happy to maintain a set of bindings generated from the spec.

to test:
```
cargo install --git=https://github.com/alsuren/dbus-rs/ --branch=generate-futures dbus-codegen
# TODO: it would probably be enough to take anything that matches `/org/bluez/hci0/*` because they all seem to implement the same interface.
dbus-codegen-rust --system-bus --destination org.bluez --path /org/bluez/hci0/dev_A4_C1_38_1E_0A_E8 --client nonblock --futures > bluez-generated/mod.rs
```

I will take this pull request out of Draft once I have something that generates working client bindings. If there is a particular direction that you would like me to take this in (like folding the `futures` flag into the `ConnectionType` enum or something) then please say.

I wasn't planning to fix the server-side codegen as part of this PR (so it will only go part-way to addressing https://github.com/diwic/dbus-rs/issues/166).


[edit: it turns out that it's already possible to generate non-blocking client interfaces as long as you disable server method generation with `--methodtype none`. I'm going to verify that this generates usable code and then think about switching this PR around to delete all `--futures`-related code]