### PR TITLE
Use {}, not {:?} in implementation of Display for Error

### DIFF
--- a/dbus/src/error.rs
+++ b/dbus/src/error.rs
@@ -82,7 +82,7 @@ impl stdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         if let Some(x) = self.message() {
-             write!(f, "{:?}", x.to_string())
+             write!(f, "{}", x)
         } else { Ok(()) }
     }
 }


### PR DESCRIPTION
Consider this example:

```rust
fn main() {
    println!("{}", dbus::Error::new_failed("Foo's bar"));
}
```

Before this change, this would output `"Foo\'s bar"`.

It now outputs `Foo's bar`.

Escaping the ' seems clearly undesired. Wrapping it all in parentheses is sometimes desirable, but then the caller should do it.