### PR TITLE
Fix edge case with object manager on '/'.

### DIFF
--- a/dbus-crossroads/src/stdimpl.rs
+++ b/dbus-crossroads/src/stdimpl.rs
@@ -345,7 +345,9 @@ fn get_managed_objects(mut ctx: Context, cr: &mut Crossroads, _: ()) -> Option<C
     let children: Vec<dbus::Path<'static>> =
         cr.get_children(ctx.path()).into_iter().map(|child_path| {
             let mut x = String::from(&**parent);
-            x.push_str("/");
+            if !x.ends_with('/') {
+                x.push_str("/");
+            }
             x.push_str(child_path);
             dbus::Path::from(x).into_static()
         }).collect();


### PR DESCRIPTION
In the special case of the object manager interface being applied on
'/', we need to skip appending the separator before the child path,
since it leads to a double-slash and hence an invalid path, which leads
to panicking down the road.

Fixes: #293