### PR TITLE
codegen: Generate struct to parse properties from HashMap.

### DIFF
--- a/dbus-codegen-tests/build.rs
+++ b/dbus-codegen-tests/build.rs
@@ -177,6 +177,7 @@ fn main() {
     generate_code(POLICYKIT_XML, &g, "policykit_asref_mtsync.rs");
 
     g.methodtype = None;
+    g.propnewtype = true;
     generate_code(POLICYKIT_XML, &g, "policykit_client.rs");
 
 }

--- a/dbus-codegen-tests/tests/test_parse_properties.rs
+++ b/dbus-codegen-tests/tests/test_parse_properties.rs
@@ -1,0 +1,31 @@
+#[allow(dead_code)]
+#[deny(trivial_casts)]
+mod policykit_client;
+
+use dbus::arg::{RefArg, Variant};
+use policykit_client::OrgFreedesktopPolicyKit1AuthorityProperties;
+use std::collections::HashMap;
+
+#[test]
+fn test_parse_properties() {
+    let mut properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+    properties.insert("BackendFeatures".to_string(), Variant(Box::new(42u32)));
+    properties.insert(
+        "BackendName".to_string(),
+        Variant(Box::new("name".to_string())),
+    );
+    let mut interfaces = HashMap::new();
+    interfaces.insert(
+        "org.freedesktop.PolicyKit1.Authority".to_string(),
+        properties,
+    );
+
+    let authority_properties =
+        OrgFreedesktopPolicyKit1AuthorityProperties::from_interfaces(&interfaces).unwrap();
+    assert_eq!(authority_properties.backend_features(), Some(42));
+    assert_eq!(
+        authority_properties.backend_name().cloned(),
+        Some("name".to_string())
+    );
+    assert_eq!(authority_properties.backend_version(), None);
+}

--- a/dbus-codegen/src/main.rs
+++ b/dbus-codegen/src/main.rs
@@ -50,6 +50,8 @@ Defaults to 'RefClosure'."))
 //             .help("Generates code to use with futures 0.3 (experimental)"))
         .arg(clap::Arg::with_name("client").short("c").long("client").takes_value(true).value_name("client")
              .help("Type of client connection. Valid values are: 'blocking', 'nonblock', 'ffidisp'."))
+        .arg(clap::Arg::with_name("propnewtype").short("n").long("prop-newtype")
+             .help("If present, will generate a struct wrapping PropMap to get properties from it with their expected types."))
         .arg(clap::Arg::with_name("output").short("o").long("output").takes_value(true).value_name("FILE")
              .help("Write output into the specified file"))
         .arg(clap::Arg::with_name("file").long("file").required(false).takes_value(true).value_name("FILE")
@@ -122,6 +124,7 @@ Defaults to 'RefClosure'."))
         genericvariant: matches.is_present("genericvariant"),
         futures: false,
         connectiontype: client,
+        propnewtype: matches.is_present("propnewtype"),
         crhandler: crhandler.map(|x| x.to_string()),
         interfaces,
         command_line: std::env::args().skip(1).collect::<Vec<String>>().join(" ")


### PR DESCRIPTION
This generates a typed wrapper around `prop_cast` for all gettable properties defined on an interface. It is useful both with `Properties::get_all` and with the interface list returned by the `ObjectManager`.