### PR TITLE
Apply the deprecated attribute if applicable interface/children are a…

### DIFF
--- a/dbus-codegen-tests/build.rs
+++ b/dbus-codegen-tests/build.rs
@@ -132,6 +132,28 @@ static POLICYKIT_XML: &'static str = r#"
 </node>
 "#;
 
+static DEPRECATED_XML: &'static str = r#"
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="com.github.dbus_rs.dbus_codegen1">
+    <annotation name="org.freedesktop.DBus.Deprecated" value="this interface is deprecated"/>
+    <method name="Method1">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="this method is deprecated"/>
+      <arg type="s" name="inbound" direction="in"/>
+      <arg type="s" name="outbound" direction="in"/>
+    </method>
+    <signal name="Signal1">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="this signal is deprecated"/>
+      <arg type="s" name="signal_name"/>
+    </signal>
+    <property name="property_name" type="s" access="readwrite">
+      <annotation name="org.freedesktop.DBus.Deprecated" value="this property is deprecated"/>
+    </property>
+  </interface>
+</node>
+"#;
+
 fn write_to_file(code: &str, path: &Path) {
     let mut f = File::create(path).unwrap();
     Write::write_all(&mut f,code.as_bytes()).unwrap();
@@ -172,6 +194,7 @@ fn main() {
         ..Default::default()
     };
     generate_code(POLICYKIT_XML, &g, "policykit_asref.rs");
+    generate_code(DEPRECATED_XML, &g, "deprecated.rs");
 
     g.methodtype = Some("MTSync".into());
     generate_code(POLICYKIT_XML, &g, "policykit_asref_mtsync.rs");

--- a/dbus-codegen/src/generate/types.rs
+++ b/dbus-codegen/src/generate/types.rs
@@ -1,4 +1,5 @@
 use std::error;
+use std::collections::HashMap;
 
 pub (super) struct Arg {
     pub name: String,
@@ -12,6 +13,7 @@ pub (super) struct Method {
     pub fn_name: String,
     pub iargs: Vec<Arg>,
     pub oargs: Vec<Arg>,
+    pub annotations: HashMap<String, String>,
 }
 
 pub (super) struct Prop {
@@ -20,11 +22,13 @@ pub (super) struct Prop {
     pub set_fn_name: String,
     pub typ: String,
     pub access: String,
+    pub annotations: HashMap<String, String>,
 }
 
 pub (super) struct Signal {
     pub name: String,
     pub args: Vec<Arg>,
+    pub annotations: HashMap<String, String>,
 }
 
 pub (super) struct Intf {
@@ -33,6 +37,7 @@ pub (super) struct Intf {
     pub methods: Vec<Method>,
     pub props: Vec<Prop>,
     pub signals: Vec<Signal>,
+    pub annotations: HashMap<String, String>,
 }
 
 const RUST_KEYWORDS: [&str; 57] = [

--- a/dbus-codegen/src/generate/write.rs
+++ b/dbus-codegen/src/generate/write.rs
@@ -43,7 +43,9 @@ fn write_method_decl(s: &mut String, m: &Method, opts: &GenOpts) -> Result<(), B
         g
     } else { vec!() };
 
-
+    m.annotations.get("org.freedesktop.DBus.Deprecated").iter().for_each(|v| {
+        *s += &format!("    #[deprecated(note = \"{}\")]\n", v);
+    });
     *s += &format!("    fn {}{}(&{}self", m.fn_name,
         if g.len() > 0 { format!("<{}>", g.join(",")) } else { "".into() },
         if opts.crossroads { "mut " } else { "" }
@@ -68,6 +70,9 @@ fn write_method_decl(s: &mut String, m: &Method, opts: &GenOpts) -> Result<(), B
 }
 
 fn write_prop_decl(s: &mut String, p: &Prop, opts: &GenOpts, set: bool) -> Result<(), Box<dyn error::Error>> {
+    p.annotations.get("org.freedesktop.DBus.Deprecated").iter().for_each(|v| {
+        *s += &format!("    #[deprecated(note = \"{}\")]\n", v);
+    });
     if set {
         *s += &format!("    fn {}(&self, value: {}) -> {}",
             p.set_fn_name, make_type(&p.typ, true, &mut None)?, make_result("()", opts));
@@ -86,6 +91,9 @@ pub (super) fn intf_name(s: &mut String, i: &Intf) -> Result<(), Box<dyn error::
 
 pub (super) fn intf(s: &mut String, i: &Intf, opts: &GenOpts) -> Result<(), Box<dyn error::Error>> {
 
+    i.annotations.get("org.freedesktop.DBus.Deprecated").iter().for_each(|v| {
+        *s += &format!("\n#[deprecated(note = \"{}\")]", v);
+    });
     let iname = make_camel(&i.shortname);
     *s += &format!("\npub trait {} {{\n", iname);
     for m in &i.methods {
@@ -109,6 +117,9 @@ pub (super) fn intf(s: &mut String, i: &Intf, opts: &GenOpts) -> Result<(), Box<
 
 fn write_signal(s: &mut String, i: &Intf, ss: &Signal) -> Result<(), Box<dyn error::Error>> {
     let structname = format!("{}{}", make_camel(&i.shortname), make_camel(&ss.name));
+    ss.annotations.get("org.freedesktop.DBus.Deprecated").iter().for_each(|v| {
+        *s += &format!("\n#[deprecated(note = \"{}\")]", v);
+    });
     *s += "\n#[derive(Debug)]\n";
     *s += &format!("pub struct {} {{\n", structname);
     for a in ss.args.iter() {


### PR DESCRIPTION
…nnotated as such.  I'm unsure how to test that the attributes are added to the appropriate entity.  But a manual check confirmed the correct behavior.