### PR TITLE
Windows support for core dbus crate

### DIFF
--- a/.github/workflows/dbus-rs-github-ci.yml
+++ b/.github/workflows/dbus-rs-github-ci.yml
@@ -25,3 +25,25 @@ jobs:
         export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --session --print-address --fork`
         cargo test --all -- --nocapture --color always
         cd dbus-codegen && cargo test --all --no-default-features -- --nocapture --color always
+
+  build-mingw:
+
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        install: >-
+          git
+          mingw-w64-x86_64-dbus
+          mingw-w64-x86_64-pkgconf
+          mingw-w64-x86_64-rust
+    - uses: actions/checkout@v2
+    - name: Run tests
+      run: |
+        # dbus-daemon has no '--fork' option on windows. But it will autolaunch
+        cd dbus && cargo test --lib -- --nocapture --color always

--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -21,6 +21,9 @@ futures-channel = { version = "0.3", optional = true }
 futures-executor = { version = "0.3", optional = true }
 # dbus-native-channel = { path = "../dbus-native-channel", version = "0.1", optional = true }
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.0", features = ["winsock2"] }
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/dbus/src/arg/basic_impl.rs
+++ b/dbus/src/arg/basic_impl.rs
@@ -230,32 +230,56 @@ impl Arg for OwnedFd {
     fn signature() -> Signature<'static> { unsafe { Signature::from_slice_unchecked("h\0") } }
 }
 impl Append for OwnedFd {
+    #[cfg(unix)]
     fn append_by_ref(&self, i: &mut IterAppend) {
         arg_append_basic(&mut i.0, ArgType::UnixFd, self.as_raw_fd())
+    }
+    #[cfg(windows)]
+    fn append_by_ref(&self, _i: &mut IterAppend) {
+        panic!("File descriptor passing not available on Windows");
     }
 }
 impl DictKey for OwnedFd {}
 impl<'a> Get<'a> for OwnedFd {
+    #[cfg(unix)]
     fn get(i: &mut Iter) -> Option<Self> {
         arg_get_basic(&mut i.0, ArgType::UnixFd).map(|fd| unsafe { OwnedFd::new(fd) })
     }
+    #[cfg(windows)]
+    fn get(_i: &mut Iter) -> Option<Self> {
+        None
+    }
 }
 
+#[cfg(unix)]
 refarg_impl!(OwnedFd, _i, { use std::os::unix::io::AsRawFd; Some(_i.as_raw_fd() as i64) }, None, None, None);
+
+#[cfg(windows)]
+refarg_impl!(OwnedFd, _i, None, None, None, None);
 
 impl Arg for File {
     const ARG_TYPE: ArgType = ArgType::UnixFd;
     fn signature() -> Signature<'static> { unsafe { Signature::from_slice_unchecked("h\0") } }
 }
 impl Append for File {
+    #[cfg(unix)]
     fn append_by_ref(&self, i: &mut IterAppend) {
         arg_append_basic(&mut i.0, ArgType::UnixFd, self.as_raw_fd())
+    }
+    #[cfg(windows)]
+    fn append_by_ref(&self, _i: &mut IterAppend) {
+        panic!("File descriptor passing not available on Windows");
     }
 }
 impl DictKey for File {}
 impl<'a> Get<'a> for File {
+    #[cfg(unix)]
     fn get(i: &mut Iter) -> Option<Self> {
         arg_get_basic(&mut i.0, ArgType::UnixFd).map(|fd| unsafe { File::from_raw_fd(fd) })
+    }
+    #[cfg(windows)]
+    fn get(_i: &mut Iter) -> Option<Self> {
+        None
     }
 }
 
@@ -270,6 +294,7 @@ impl RefArg for File {
     fn as_any(&self) -> &dyn any::Any { self }
     #[inline]
     fn as_any_mut(&mut self) -> &mut dyn any::Any { self }
+    #[cfg(unix)]
     #[inline]
     fn as_i64(&self) -> Option<i64> { Some(self.as_raw_fd() as i64) }
     #[inline]

--- a/dbus/src/blocking.rs
+++ b/dbus/src/blocking.rs
@@ -427,9 +427,12 @@ fn test_peer() {
 
     let s2 = j.join().unwrap();
 
-    let proxy = c.with_proxy("org.a11y.Bus", "/org/a11y/bus", Duration::from_secs(5));
-    let (s1,): (String,) = proxy.method_call("org.freedesktop.DBus.Peer", "GetMachineId", ()).unwrap();
+    #[cfg(unix)]
+    {
+        let proxy = c.with_proxy("org.a11y.Bus", "/org/a11y/bus", Duration::from_secs(5));
+        let (s1,): (String,) = proxy.method_call("org.freedesktop.DBus.Peer", "GetMachineId", ()).unwrap();
 
-    assert_eq!(s1, s2);
+        assert_eq!(s1, s2);
+    }
 
 }

--- a/dbus/src/channel.rs
+++ b/dbus/src/channel.rs
@@ -4,7 +4,6 @@
 
 use crate::{Message, to_c_str, c_str_to_slice, MessageType};
 use crate::message::MatchRule;
-use std::os::unix::io::RawFd;
 
 #[cfg(not(feature = "native-channel"))]
 mod ffichannel;
@@ -28,12 +27,19 @@ pub enum BusType {
     Starter = ffi::DBusBusType::Starter as isize,
 }
 
+/// Platform-specific file descriptor type
+#[cfg(unix)]
+pub type Fd = std::os::unix::io::RawFd;
+
+/// Platform-specific file descriptor type
+#[cfg(windows)]
+pub type Fd = std::os::windows::io::RawSocket;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 /// A file descriptor, and an indication whether it should be read from, written to, or both.
 pub struct Watch {
     /// File descriptor
-    pub fd: RawFd,
+    pub fd: Fd,
     /// True if wakeup should happen when the file descriptor is ready for reading
     pub read: bool,
     /// True if wakeup should happen when the file descriptor is ready for writing

--- a/dbus/src/ffidisp/connection.rs
+++ b/dbus/src/ffidisp/connection.rs
@@ -1,11 +1,10 @@
 //! Contains structs and traits relevant to the connection itself, and dispatching incoming messages. 
 
-use crate::{Error, ffi, to_c_str, c_str_to_slice, Message, MessageType};
+use crate::{Error, Message, MessageType, c_str_to_slice, channel::Fd, ffi, to_c_str};
 use crate::ffidisp::ConnPath;
 use std::{fmt, mem, ptr, thread, panic, ops};
 use std::{collections::VecDeque, time::Duration};
 use std::cell::{Cell, RefCell};
-use std::os::unix::io::RawFd;
 use std::os::raw::{c_void, c_char, c_int, c_uint};
 use crate::strings::{BusName, Path};
 use super::{Watch, WatchList, MessageCallback, ConnectionItem, MsgHandler, MsgHandlerList, MessageReply, BusType};
@@ -338,11 +337,10 @@ impl Connection {
     /// The returned iterator will return pending items only, never block for new events.
     ///
     /// See the `Watch` struct for an example.
-    pub fn watch_handle(&self, fd: RawFd, flags: c_uint) -> ConnectionItems {
+    pub fn watch_handle(&self, fd: Fd, flags: c_uint) -> ConnectionItems {
         self.i.watches.as_ref().unwrap().watch_handle(fd, flags);
         ConnectionItems::new(self, None, true)
     }
-
 
     /// Create a convenience struct for easier calling of many methods on the same destination and path.
     pub fn with_path<'a, D: Into<BusName<'a>>, P: Into<Path<'a>>>(&'a self, dest: D, path: P, timeout_ms: i32) ->

--- a/dbus/src/ffidisp/watch.rs
+++ b/dbus/src/ffidisp/watch.rs
@@ -1,10 +1,17 @@
-use crate::ffi;
+use crate::{channel::Fd, ffi};
 use libc;
 use crate::ffidisp::Connection;
 
 use std::mem;
 use std::sync::{Mutex, RwLock};
+#[cfg(unix)]
 use std::os::unix::io::{RawFd, AsRawFd};
+#[cfg(windows)]
+use std::os::windows::io::{RawSocket, AsRawSocket};
+#[cfg(unix)]
+use libc::{POLLIN, POLLOUT, POLLERR, POLLHUP};
+#[cfg(windows)]
+use winapi::um::winsock2::{POLLIN, POLLOUT, POLLERR, POLLHUP};
 use std::os::raw::{c_void, c_uint};
 
 /// A file descriptor to watch for incoming events (for async I/O).
@@ -54,39 +61,56 @@ impl WatchEvent {
     /// After running poll, this transforms the revents into a parameter you can send into `Connection::watch_handle`
     pub fn from_revents(revents: libc::c_short) -> c_uint {
         0 +
-        if (revents & libc::POLLIN) != 0 { WatchEvent::Readable as c_uint } else { 0 } +
-        if (revents & libc::POLLOUT) != 0 { WatchEvent::Writable as c_uint } else { 0 } +
-        if (revents & libc::POLLERR) != 0 { WatchEvent::Error as c_uint } else { 0 } +
-        if (revents & libc::POLLHUP) != 0 { WatchEvent::Hangup as c_uint } else { 0 }
+        if (revents & POLLIN) != 0 { WatchEvent::Readable as c_uint } else { 0 } +
+        if (revents & POLLOUT) != 0 { WatchEvent::Writable as c_uint } else { 0 } +
+        if (revents & POLLERR) != 0 { WatchEvent::Error as c_uint } else { 0 } +
+        if (revents & POLLHUP) != 0 { WatchEvent::Hangup as c_uint } else { 0 }
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 /// A file descriptor, and an indication whether it should be read from, written to, or both.
 pub struct Watch {
-    fd: RawFd,
+    fd: Fd,
     read: bool,
     write: bool,
 }
 
 impl Watch {
     /// Get the RawFd this Watch is for
-    pub fn fd(&self) -> RawFd { self.fd }
+    pub fn fd(&self) -> Fd { self.fd }
     /// Add POLLIN to events to listen for
     pub fn readable(&self) -> bool { self.read }
     /// Add POLLOUT to events to listen for
     pub fn writable(&self) -> bool { self.write }
     /// Returns the current watch as a libc::pollfd, to use with libc::poll
+    #[cfg(unix)]
     pub fn to_pollfd(&self) -> libc::pollfd {
-        libc::pollfd { fd: self.fd, revents: 0, events: libc::POLLERR + libc::POLLHUP +
-            if self.readable() { libc::POLLIN } else { 0 } +
-            if self.writable() { libc::POLLOUT } else { 0 },
+        libc::pollfd { fd: self.fd, revents: 0, events: POLLERR + POLLHUP +
+            if self.readable() { POLLIN } else { 0 } +
+            if self.writable() { POLLOUT } else { 0 },
+        }
+    }
+    /// Returns the current watch as a winapi::um::winsock2::WSAPOLLFD, to use with winapi::um::winsock2::WSAPoll
+    #[cfg(windows)]
+    pub fn to_pollfd(&self) -> winapi::um::winsock2::WSAPOLLFD {
+        winapi::um::winsock2::WSAPOLLFD {
+            fd: self.fd as winapi::um::winsock2::SOCKET,
+            revents: 0, events: 0 +
+            if self.readable() { POLLIN } else { 0 } +
+            if self.writable() { POLLOUT } else { 0 },
         }
     }
 }
 
+#[cfg(unix)]
 impl AsRawFd for Watch {
     fn as_raw_fd(&self) -> RawFd { self.fd }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for Watch {
+    fn as_raw_socket(&self) -> RawSocket { self.fd }
 }
 
 /// Note - internal struct, not to be used outside API. Moving it outside its box will break things.
@@ -108,7 +132,7 @@ impl WatchList {
 
     pub fn set_on_update(&self, on_update: Box<dyn Fn(Watch) + Send>) { *self.on_update.lock().unwrap() = on_update; }
 
-    pub fn watch_handle(&self, fd: RawFd, flags: c_uint) {
+    pub fn watch_handle(&self, fd: Fd, flags: c_uint) {
         // println!("watch_handle {} flags {}", fd, flags);
         for &q in self.watches.read().unwrap().iter() {
             let w = self.get_watch(q);
@@ -125,7 +149,10 @@ impl WatchList {
     }
 
     fn get_watch(&self, watch: *mut ffi::DBusWatch) -> Watch {
+        #[cfg(unix)]
         let mut w = Watch { fd: unsafe { ffi::dbus_watch_get_unix_fd(watch) }, read: false, write: false};
+        #[cfg(windows)]
+        let mut w = Watch { fd: unsafe { ffi::dbus_watch_get_socket(watch) as RawSocket }, read: false, write: false};
         let enabled = self.watches.read().unwrap().contains(&watch) && unsafe { ffi::dbus_watch_get_enabled(watch) != 0 };
         let flags = unsafe { ffi::dbus_watch_get_flags(watch) };
         if enabled {
@@ -187,8 +214,10 @@ extern "C" fn toggled_watch_cb(watch: *mut ffi::DBusWatch, data: *mut c_void) {
 
 #[cfg(test)]
 mod test {
+    #[cfg(unix)]
     use libc;
     use super::super::{Connection, Message, BusType, WatchEvent, ConnectionItem, MessageType};
+    use super::{POLLIN, POLLOUT};
 
     #[test]
     fn test_async() {
@@ -208,14 +237,23 @@ mod test {
 
             for f in fds.iter_mut() { f.revents = 0 };
 
+            #[cfg(unix)]
             assert!(unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, 1000) } > 0);
+
+            #[cfg(windows)]
+            assert!(unsafe { winapi::um::winsock2::WSAPoll(fds.as_mut_ptr(), fds.len() as u32, 1000) } > 0);
 
             for f in fds.iter().filter(|pfd| pfd.revents != 0) {
                 let m = WatchEvent::from_revents(f.revents);
                 println!("Async: fd {}, revents {} -> {}", f.fd, f.revents, m);
-                assert!(f.revents & libc::POLLIN != 0 || f.revents & libc::POLLOUT != 0);
+                assert!(f.revents & POLLIN != 0 || f.revents & POLLOUT != 0);
 
-                for e in c.watch_handle(f.fd, m) {
+                #[cfg(unix)]
+                let fd = f.fd;
+                #[cfg(windows)]
+                let fd = f.fd as std::os::windows::io::RawSocket;
+
+                for e in c.watch_handle(fd, m) {
                     println!("Async: got {:?}", e);
                     match e {
                         ConnectionItem::MethodCall(m) => {

--- a/libdbus-sys/src/lib.rs
+++ b/libdbus-sys/src/lib.rs
@@ -272,6 +272,7 @@ extern "C" {
     pub fn dbus_watch_get_enabled(watch: *mut DBusWatch) -> u32;
     pub fn dbus_watch_get_flags(watch: *mut DBusWatch) -> c_uint;
     pub fn dbus_watch_get_unix_fd(watch: *mut DBusWatch) -> c_int;
+    pub fn dbus_watch_get_socket(watch: *mut DBusWatch) -> c_int;
     pub fn dbus_watch_handle(watch: *mut DBusWatch, flags: c_uint) -> u32;
     pub fn dbus_watch_get_data(watch: *mut DBusWatch) -> *mut c_void;
     pub fn dbus_watch_set_data(watch: *mut DBusWatch, user_data: *mut c_void,


### PR DESCRIPTION
Work in progress.

All tests pass for `dbus` crate in MSYS2/mingw environment (though I disabled some parts of the tests that tried to use fd passing or linux d-bus services):

~~~ console
> cargo test --lib
warning: variable does not need to be mutable
   --> dbus\src\arg\messageitem.rs:690:13
    |
690 |         let mut m = Message::new_method_call(&c.unique_name(), "/hello", "com.example.hello", "Hello").unwrap();
    |             ----^
    |             |
    |             help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running C:\msys64\home\Aleksandr\dbus-rs\target\debug\deps\dbus-211e6d1e731d7e8a.exe

running 33 tests
test arg::messageitem::test::dict_of_dicts ... ok
test arg::messageitem::test::inner_from_variant ... ok
test arg::messageitem::test::issue24 ... ok
test arg::messageitem::test::message_inner_str ... ok
test arg::messageitem::test::message_listnames ... ok
test arg::messageitem::test::message_namehasowner ... ok
test arg::messageitem::test::message_peel ... ok
test arg::messageitem::test::message_types ... ok
test arg::messageitem::test::unix_fd ... ok
test arg::msgarg::test::cast_dicts ... ok
test arg::msgarg::test::cast_vecs ... ok
test arg::msgarg::test::message_types ... ok
test arg::msgarg::test::refarg ... ok
test blocking::test_add_match ... ok
test blocking::test_conn_send_sync ... ok
test channel::channel_simple_test ... ok
test channel::test_bus_type_is_compatible_with_set ... ok
test channel::test_channel_send_sync ... ok
test channel::watchmap ... ok
test ffidisp::connection::message_reply ... ok
test ffidisp::test::connection ... ok
test ffidisp::test::invalid_message ... ok
test ffidisp::test::object_path ... ok
test ffidisp::test::register_name ... ok
test ffidisp::test::signal ... ok
test ffidisp::test::watch ... ok
test ffidisp::watch::test::test_async ... ok
test message::signalargs::intf_removed ... ok
test message::test::marshal ... ok
test message::test::set_valid_destination ... ok
test strings::make_sig ... ok
test strings::reborrow_path ... ok
test strings::some_path ... ok

test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
~~~

All tests pass for `dbus-crossroads`:
~~~ console
$ cargo test --lib
warning: missing documentation for an associated function
  --> dbus\src\ffidisp\watch.rs:96:5
   |
96 |     pub fn to_pollfd(&self) -> winapi::um::winsock2::WSAPOLLFD {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> dbus\src\lib.rs:18:9
   |
18 | #![warn(missing_docs)]
   |         ^^^^^^^^^^^^

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running C:\msys64\home\Aleksandr\dbus-rs\target\debug\deps\dbus_crossroads-10e96f8b1099f258.exe

running 5 tests
test test::introspect ... ok
test test::object_manager ... ok
test test::object_manager_root ... ok
test test::score ... ok
test test::test_send ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
~~~

`dbus-tokio` fails to compile:
~~~
error[E0433]: failed to resolve: could not find `unix` in `os`
  --> dbus-tokio\src\connection.rs:44:14
   |
44 | use std::os::unix::io::RawFd;
   |              ^^^^ could not find `unix` in `os`

error[E0432]: unresolved import `tokio::io::unix`
  --> dbus-tokio\src\connection.rs:46:16
   |
46 | use tokio::io::unix::{AsyncFd, AsyncFdReadyGuard};
   |                ^^^^ could not find `unix` in `io`

error[E0412]: cannot find type `RawFd` in this scope
  --> dbus-tokio\src\connection.rs:58:18
   |
58 |     Unregistered(RawFd, tokio::io::Interest),
   |                  ^^^^^ not found in this scope

error[E0412]: cannot find type `RawFd` in this scope
  --> dbus-tokio\src\connection.rs:59:24
   |
57 | enum IOResourceRegistration {
   |                            - help: you might be missing a type parameter: `<RawFd>`
58 |     Unregistered(RawFd, tokio::io::Interest),
59 |     Registered(AsyncFd<RawFd>),
   |                        ^^^^^ not found in this scope

error[E0425]: cannot find function `recv` in crate `libc`
   --> dbus-tokio\src\connection.rs:170:27
    |
170 |                     libc::recv(watch_fd, &mut x as *mut _ as *mut libc::c_void, 1, libc::MSG_DONTWAIT | libc::MSG_PEEK)
    |                           ^^^^ not found in `libc`
    |
help: consider importing this function
    |
38  | use crate::connection::io::sys::c::recv;
    |

error[E0425]: cannot find value `MSG_DONTWAIT` in crate `libc`
   --> dbus-tokio\src\connection.rs:170:90
    |
170 |                     libc::recv(watch_fd, &mut x as *mut _ as *mut libc::c_void, 1, libc::MSG_DONTWAIT | libc::MSG_PEEK)
    |                                                                                          ^^^^^^^^^^^^ not found in `libc`

error[E0425]: cannot find value `MSG_PEEK` in crate `libc`
   --> dbus-tokio\src\connection.rs:170:111
    |
170 |                     libc::recv(watch_fd, &mut x as *mut _ as *mut libc::c_void, 1, libc::MSG_DONTWAIT | libc::MSG_PEEK)
    |                                                                                                               ^^^^^^^^ not found in `libc`
    |
help: consider importing this constant
    |
38  | use crate::connection::io::sys::c::MSG_PEEK;
    |

error[E0412]: cannot find type `RawFd` in this scope
   --> dbus-tokio\src\connection.rs:188:50
    |
187 | fn check_ready_now<'a>(
    |                      - help: you might be missing a type parameter: `, RawFd`
188 |     guard: &mut task::Poll<AsyncFdReadyGuard<'a, RawFd>>,
    |                                                  ^^^^^ not found in this scope

error[E0412]: cannot find type `RawFd` in this scope
   --> dbus-tokio\src\connection.rs:189:83
    |
187 | fn check_ready_now<'a>(
    |                      - help: you might be missing a type parameter: `, RawFd`
188 |     guard: &mut task::Poll<AsyncFdReadyGuard<'a, RawFd>>,
189 |     poll_ready: impl FnOnce() -> task::Poll<std::io::Result<AsyncFdReadyGuard<'a, RawFd>>>,
    |                                                                                   ^^^^^ not found in this scope

error: aborting due to 9 previous errors

Some errors have detailed explanations: E0412, E0425, E0432, E0433.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `dbus-tokio`
~~~

https://github.com/diwic/dbus-rs/issues/236