### PR TITLE
Remove extra futures dependencies

### DIFF
--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.66"
 libdbus-sys = { path = "../libdbus-sys", version = "0.2" }
-futures-util = { version = "0.3", optional = true, features = ["io"] }
+futures-util = { version = "0.3", optional = true, default-features = false }
 futures-channel = { version = "0.3", optional = true }
 futures-executor = { version = "0.3", optional = true }
 # dbus-native-channel = { path = "../dbus-native-channel", version = "0.1", optional = true }
@@ -31,7 +31,7 @@ tempfile = "3"
 no-string-validation = []
 futures = ["futures-util", "futures-channel"]
 # Not ready yet
-# native-channel = ["futures-executor", "futures-util", "dbus-native-channel"]
+# native-channel = ["futures-executor", "futures-util/io", "dbus-native-channel"]
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Removes dependencies on futures-io, futures-macro (which has transitive deps on quote, syn, proc-macro2 and others), memchr, pin-project-lite, pin-utils, proc-macro-hack, proc-macro-nested, and slab. Should significantly speed up compilation when building with `futures` feature.