### PR TITLE
Send Message to all matching MsgMatches

### DIFF
--- a/dbus/src/filters.rs
+++ b/dbus/src/filters.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::vec::Vec;
 use crate::message::MatchRule;
 use crate::Message;
 use crate::channel::Token;
@@ -32,11 +33,12 @@ impl<F> Filters<F> {
         self.list.remove(&id)
     }
 
-    pub fn remove_matching(&mut self, msg: &Message) -> Option<(Token, MatchRule<'static>, F)> {
-        if let Some(k) = self.list.iter_mut().find(|(_, v)| v.0.matches(&msg)).map(|(k, _)| *k) {
+    /// Removes and returns all filters which match the given message.
+    pub fn remove_matching(&mut self, msg: &Message) -> Vec<(Token, MatchRule<'static>, F)> {
+        let matching: Vec<_> = self.list.iter().filter_map(|(k, v)| if v.0.matches(&msg) { Some(*k) } else { None }).collect();
+        matching.into_iter().map(|k| {
             let v = self.list.remove(&k).unwrap();
-            Some((k, v.0, v.1))
-        } else { None }
+            (k, v.0, v.1)
+        }).collect()
     }
-
 }

--- a/dbus/src/message.rs
+++ b/dbus/src/message.rs
@@ -59,6 +59,20 @@ impl Message {
         Message { msg: ptr}
     }
 
+    /// Creates a new message that is a replica of this message, but without a serial.
+    ///
+    /// May fail if out of memory or file descriptors.
+    pub fn duplicate(&self) -> Result<Self, String> {
+        let ptr = unsafe {
+            ffi::dbus_message_copy(self.msg)
+        };
+        if ptr.is_null() {
+            Err("D-Bus error: dbus_message_copy failed".into())
+        } else {
+            Ok(Message { msg: ptr })
+        }
+    }
+
     /// Creates a new method call message.
     pub fn call_with_args<'d, 'p, 'i, 'm, A, D, P, I, M>(destination: D, path: P, iface: I, method: M, args: A) -> Message
     where D: Into<BusName<'d>>, P: Into<Path<'p>>, I: Into<Interface<'i>>, M: Into<Member<'m>>, A: AppendAll {

--- a/dbus/src/nonblock.rs
+++ b/dbus/src/nonblock.rs
@@ -178,13 +178,21 @@ impl Process for $c {
                 return;
             }
         }
-        let ff = self.filters_mut().remove_matching(&msg);
-        if let Some(mut ff) = ff {
-            if ff.2(msg, self) {
+        let matching_filters = self.filters_mut().remove_matching(&msg);
+        if matching_filters.is_empty() {
+            if let Some(reply) = crate::channel::default_reply(&msg) {
+                let _ = self.send(reply);
+            }
+        }
+        for mut ff in matching_filters {
+            if let Ok(copy) = msg.duplicate() {
+                if ff.2(copy, self) {
+                    self.filters_mut().insert(ff);
+                }
+            } else {
+                // Silently drop the message, but add the filter back.
                 self.filters_mut().insert(ff);
             }
-        } else if let Some(reply) = crate::channel::default_reply(&msg) {
-            let _ = self.send(reply);
         }
     }
 }

--- a/libdbus-sys/src/lib.rs
+++ b/libdbus-sys/src/lib.rs
@@ -238,6 +238,7 @@ extern "C" {
     pub fn dbus_message_set_no_reply(message: *mut DBusMessage, no_reply: u32);
     pub fn dbus_message_get_auto_start(message: *mut DBusMessage) -> u32;
     pub fn dbus_message_set_auto_start(message: *mut DBusMessage, no_reply: u32);
+    pub fn dbus_message_copy(message: *const DBusMessage) -> *mut DBusMessage;
 
     pub fn dbus_message_iter_append_basic(iter: *mut DBusMessageIter, t: c_int, value: *const c_void) -> u32;
     pub fn dbus_message_iter_append_fixed_array(iter: *mut DBusMessageIter, element_type: c_int,


### PR DESCRIPTION
If there are multiple `MsgMatch`es registered that match a message, it should be sent to all of them rather than just the first one. This requires a way to make a copy of the message, which I've done with `dbus_message_copy`. (It's not quite a clone, because it can fail.)

This fixes #346.