### PR TITLE
Add option to send signals to all matching MsgMatches

### DIFF
--- a/dbus/src/blocking.rs
+++ b/dbus/src/blocking.rs
@@ -4,7 +4,7 @@
 use crate::strings::{BusName, Path, Interface, Member};
 use crate::arg::{AppendAll, ReadAll, IterAppend};
 use crate::{channel, Error, Message};
-use crate::message::{MatchRule, SignalArgs};
+use crate::message::{MatchRule, SignalArgs, MessageType};
 use crate::channel::{Channel, BusType, Token};
 use std::{cell::RefCell, time::Duration, sync::Mutex};
 use crate::filters::Filters;
@@ -111,18 +111,21 @@ pub mod stdintf {
 pub struct LocalConnection {
     channel: Channel,
     filters: RefCell<Filters<LocalFilterCb>>,
+    all_signal_matches: bool,
 }
 
 /// A connection to D-Bus, non-async version where callbacks are Send but not Sync.
 pub struct Connection {
     channel: Channel,
     filters: RefCell<Filters<FilterCb>>,
+    all_signal_matches: bool,
 }
 
 /// A connection to D-Bus, Send + Sync + non-async version
 pub struct SyncConnection {
     channel: Channel,
-    filters: Mutex<Filters<SyncFilterCb>>
+    filters: Mutex<Filters<SyncFilterCb>>,
+    all_signal_matches: bool,
 }
 
 use crate::blocking::stdintf::org_freedesktop_dbus;
@@ -173,6 +176,10 @@ impl $c {
 
     /// Adds a new match to the connection, and sets up a callback when this message arrives.
     ///
+    /// If multiple [`MatchRule`]s match the same message, then by default only one of them will get
+    /// the callback. No guarantee is made about which one. This behaviour can be changed for signal
+    /// messages by calling [`all_signal_matches`](Self::all_signal_matches).
+    ///
     /// The returned value can be used to remove the match. The match is also removed if the callback
     /// returns "false".
     pub fn add_match<S: ReadAll, F>(&self, match_rule: MatchRule<'static>, f: F) -> Result<Token, Error>
@@ -204,6 +211,19 @@ impl $c {
         self.remove_match_no_cb(&mr.match_str())
     }
 
+    /// If true, configures the connection to send signal messages to all matching [`MatchRule`]
+    /// filters added with [`add_match`](Self::add_match) rather than just the first one. This will
+    /// result in the messages being duplicated, and so the message serial will be lost, but this is
+    /// generally not a problem for signals.
+    ///
+    /// This is false by default, for a newly-created connection.
+    ///
+    /// When `all_signal_matches` mode is enabled, removing other matches from inside a match
+    /// callback is not supported.
+    pub fn set_all_signal_matches(&mut self, all_signal_matches: bool) {
+        self.all_signal_matches = all_signal_matches;
+    }
+
     /// Tries to handle an incoming message if there is one. If there isn't one,
     /// it will wait up to timeout
     ///
@@ -211,20 +231,28 @@ impl $c {
     /// it recursively and might lead to panics or deadlocks.
     pub fn process(&self, timeout: Duration) -> Result<bool, Error> {
         if let Some(msg) = self.channel.blocking_pop_message(timeout)? {
-            let matching_filters = self.filters_mut().remove_matching(&msg);
-            if matching_filters.is_empty() {
-                if let Some(reply) = crate::channel::default_reply(&msg) {
-                    let _ = self.channel.send(reply);
-                }
-            }
-            for mut ff in matching_filters {
-                if let Ok(copy) = msg.duplicate() {
-                    if ff.2(copy, self) {
+            if self.all_signal_matches && msg.msg_type() == MessageType::Signal {
+                // If it's a signal and the mode is enabled, send a copy of the message to all
+                // matching filters.
+                for mut ff in self.filters_mut().remove_all_matching(&msg) {
+                    if let Ok(copy) = msg.duplicate() {
+                        if ff.2(copy, self) {
+                            self.filters_mut().insert(ff);
+                        }
+                    } else {
+                        // Silently drop the message, but add the filter back.
                         self.filters_mut().insert(ff);
                     }
-                } else {
-                    // Silently drop the message, but add the filter back.
-                    self.filters_mut().insert(ff);
+                }
+            } else {
+                // Otherwise, send the original message to only the first matching filter.
+                let ff = self.filters_mut().remove_first_matching(&msg);
+                if let Some(mut ff) = ff {
+                    if ff.2(msg, self) {
+                        self.filters_mut().insert(ff);
+                    }
+                } else if let Some(reply) = crate::channel::default_reply(&msg) {
+                    let _ = self.channel.send(reply);
                 }
             }
             Ok(true)
@@ -247,7 +275,9 @@ impl BlockingSender for $c {
 
 impl From<Channel> for $c {
     fn from(channel: Channel) -> $c { $c {
-        channel, filters: Default::default(),
+        channel,
+        filters: Default::default(),
+        all_signal_matches: false,
     } }
 }
 

--- a/dbus/src/filters.rs
+++ b/dbus/src/filters.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::vec::Vec;
 use crate::message::MatchRule;
 use crate::Message;
 use crate::channel::Token;
@@ -32,11 +33,12 @@ impl<F> Filters<F> {
         self.list.remove(&id)
     }
 
-    pub fn remove_matching(&mut self, msg: &Message) -> Option<(Token, MatchRule<'static>, F)> {
-        if let Some(k) = self.list.iter_mut().find(|(_, v)| v.0.matches(&msg)).map(|(k, _)| *k) {
+    /// Removes and returns all filters which match the given message.
+    pub fn remove_matching(&mut self, msg: &Message) -> Vec<(Token, MatchRule<'static>, F)> {
+        let matching: Vec<_> = self.list.iter().filter_map(|(k, v)| if v.0.matches(&msg) { Some(*k) } else { None }).collect();
+        matching.into_iter().map(|k| {
             let v = self.list.remove(&k).unwrap();
-            Some((k, v.0, v.1))
-        } else { None }
+            (k, v.0, v.1)
+        }).collect()
     }
-
 }

--- a/dbus/src/filters.rs
+++ b/dbus/src/filters.rs
@@ -33,12 +33,25 @@ impl<F> Filters<F> {
         self.list.remove(&id)
     }
 
-    /// Removes and returns all filters which match the given message.
-    pub fn remove_matching(&mut self, msg: &Message) -> Vec<(Token, MatchRule<'static>, F)> {
-        let matching: Vec<_> = self.list.iter().filter_map(|(k, v)| if v.0.matches(&msg) { Some(*k) } else { None }).collect();
-        matching.into_iter().map(|k| {
+    /// Removes and returns the first filter which matches the given message.
+    pub fn remove_first_matching(&mut self, msg: &Message) -> Option<(Token, MatchRule<'static>, F)> {
+        if let Some(k) = self.list.iter_mut().find_map(|(k, v)| if v.0.matches(&msg) { Some(*k) } else { None }) {
             let v = self.list.remove(&k).unwrap();
-            (k, v.0, v.1)
-        }).collect()
+            Some((k, v.0, v.1))
+        } else {
+            None
+        }
+    }
+
+    /// Removes and returns all filters which match the given message.
+    pub fn remove_all_matching(&mut self, msg: &Message) -> Vec<(Token, MatchRule<'static>, F)> {
+        let matching: Vec<_> = self.list.iter().filter_map(|(k, v)| if v.0.matches(&msg) { Some(*k) } else { None }).collect();
+        matching
+            .into_iter()
+            .map(|k| {
+                let v = self.list.remove(&k).unwrap();
+                (k, v.0, v.1)
+            })
+            .collect()
     }
 }

--- a/dbus/src/message.rs
+++ b/dbus/src/message.rs
@@ -59,6 +59,20 @@ impl Message {
         Message { msg: ptr}
     }
 
+    /// Creates a new message that is a replica of this message, but without a serial.
+    ///
+    /// May fail if out of memory or file descriptors.
+    pub fn duplicate(&self) -> Result<Self, String> {
+        let ptr = unsafe {
+            ffi::dbus_message_copy(self.msg)
+        };
+        if ptr.is_null() {
+            Err("D-Bus error: dbus_message_copy failed".into())
+        } else {
+            Ok(Message { msg: ptr })
+        }
+    }
+
     /// Creates a new method call message.
     pub fn call_with_args<'d, 'p, 'i, 'm, A, D, P, I, M>(destination: D, path: P, iface: I, method: M, args: A) -> Message
     where D: Into<BusName<'d>>, P: Into<Path<'p>>, I: Into<Interface<'i>>, M: Into<Member<'m>>, A: AppendAll {

--- a/dbus/src/nonblock.rs
+++ b/dbus/src/nonblock.rs
@@ -17,7 +17,7 @@ use crate::{Error, Message};
 use crate::channel::{MatchingReceiver, Channel, Sender, Token};
 use crate::strings::{BusName, Path, Interface, Member};
 use crate::arg::{AppendAll, ReadAll, IterAppend};
-use crate::message::MatchRule;
+use crate::message::{MatchRule, MessageType};
 
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
@@ -75,6 +75,7 @@ pub struct LocalConnection {
     replies: RefCell<Replies<LocalRepliesCb>>,
     timeout_maker: Option<TimeoutMakerCb>,
     waker: Option<WakerCb>,
+    all_signal_matches: bool,
 }
 
 /// A connection to D-Bus, async version, which is Send but not Sync.
@@ -84,6 +85,7 @@ pub struct Connection {
     replies: RefCell<Replies<RepliesCb>>,
     timeout_maker: Option<TimeoutMakerCb>,
     waker: Option<WakerCb>,
+    all_signal_matches: bool,
 }
 
 /// A connection to D-Bus, Send + Sync + async version
@@ -93,6 +95,7 @@ pub struct SyncConnection {
     replies: Mutex<Replies<SyncRepliesCb>>,
     timeout_maker: Option<TimeoutMakerCb>,
     waker: Option<WakerCb>,
+    all_signal_matches: bool,
 }
 
 use stdintf::org_freedesktop_dbus::DBus;
@@ -113,6 +116,7 @@ impl From<Channel> for $c {
             filters: Default::default(),
             timeout_maker: None,
             waker: None,
+            all_signal_matches: false,
         }
     }
 }
@@ -188,20 +192,28 @@ impl Process for $c {
                 return;
             }
         }
-        let matching_filters = self.filters_mut().remove_matching(&msg);
-        if matching_filters.is_empty() {
-            if let Some(reply) = crate::channel::default_reply(&msg) {
-                let _ = self.send(reply);
-            }
-        }
-        for mut ff in matching_filters {
-            if let Ok(copy) = msg.duplicate() {
-                if ff.2(copy, self) {
+        if self.all_signal_matches && msg.msg_type() == MessageType::Signal {
+            // If it's a signal and the mode is enabled, send a copy of the message to all
+            // matching filters.
+            for mut ff in self.filters_mut().remove_all_matching(&msg) {
+                if let Ok(copy) = msg.duplicate() {
+                    if ff.2(copy, self) {
+                        self.filters_mut().insert(ff);
+                    }
+                } else {
+                    // Silently drop the message, but add the filter back.
                     self.filters_mut().insert(ff);
                 }
-            } else {
-                // Silently drop the message, but add the filter back.
-                self.filters_mut().insert(ff);
+            }
+        } else {
+            // Otherwise, send the original message to only the first matching filter.
+            let ff = self.filters_mut().remove_first_matching(&msg);
+            if let Some(mut ff) = ff {
+                if ff.2(msg, self) {
+                    self.filters_mut().insert(ff);
+                }
+            } else if let Some(reply) = crate::channel::default_reply(&msg) {
+                let _ = self.channel.send(reply);
             }
         }
     }
@@ -246,6 +258,10 @@ impl $c {
 
     /// Adds a new match to the connection, and sets up a callback when this message arrives.
     ///
+    /// If multiple [`MatchRule`]s match the same message, then by default only one of them will get
+    /// the callback. No guarantee is made about which one. This behaviour can be changed for signal
+    /// messages by calling [`all_signal_matches`](Self::all_signal_matches).
+    ///
     /// The returned value can be used to remove the match.
     pub async fn add_match(&self, match_rule: MatchRule<'static>) -> Result<MsgMatch, Error> {
         let m = match_rule.match_str();
@@ -277,6 +293,19 @@ impl $c {
     pub async fn remove_match(&self, id: Token) -> Result<(), Error> {
         let (mr, _) = self.stop_receive(id).ok_or_else(|| Error::new_failed("No match with that id found"))?;
         self.remove_match_no_cb(&mr.match_str()).await
+    }
+
+    /// If true, configures the connection to send signal messages to all matching [`MatchRule`]
+    /// filters added with [`add_match`](Self::add_match) rather than just the first one. This will
+    /// result in the messages being duplicated, and so the message serial will be lost, but this is
+    /// generally not a problem for signals.
+    ///
+    /// This is false by default, for a newly-created connection.
+    ///
+    /// When `all_signal_matches` mode is enabled, removing other matches from inside a match
+    /// callback is not supported.
+    pub fn set_all_signal_matches(&mut self, all_signal_matches: bool) {
+        self.all_signal_matches = all_signal_matches;
     }
 }
 

--- a/dbus/src/nonblock.rs
+++ b/dbus/src/nonblock.rs
@@ -188,13 +188,21 @@ impl Process for $c {
                 return;
             }
         }
-        let ff = self.filters_mut().remove_matching(&msg);
-        if let Some(mut ff) = ff {
-            if ff.2(msg, self) {
+        let matching_filters = self.filters_mut().remove_matching(&msg);
+        if matching_filters.is_empty() {
+            if let Some(reply) = crate::channel::default_reply(&msg) {
+                let _ = self.send(reply);
+            }
+        }
+        for mut ff in matching_filters {
+            if let Ok(copy) = msg.duplicate() {
+                if ff.2(copy, self) {
+                    self.filters_mut().insert(ff);
+                }
+            } else {
+                // Silently drop the message, but add the filter back.
                 self.filters_mut().insert(ff);
             }
-        } else if let Some(reply) = crate::channel::default_reply(&msg) {
-            let _ = self.send(reply);
         }
     }
 }

--- a/libdbus-sys/src/lib.rs
+++ b/libdbus-sys/src/lib.rs
@@ -238,6 +238,7 @@ extern "C" {
     pub fn dbus_message_set_no_reply(message: *mut DBusMessage, no_reply: u32);
     pub fn dbus_message_get_auto_start(message: *mut DBusMessage) -> u32;
     pub fn dbus_message_set_auto_start(message: *mut DBusMessage, no_reply: u32);
+    pub fn dbus_message_copy(message: *const DBusMessage) -> *mut DBusMessage;
 
     pub fn dbus_message_iter_append_basic(iter: *mut DBusMessageIter, t: c_int, value: *const c_void) -> u32;
     pub fn dbus_message_iter_append_fixed_array(iter: *mut DBusMessageIter, element_type: c_int,


### PR DESCRIPTION
If there are multiple `MsgMatch`es registered that match a signal message, it should be sent to all of them rather than just the first one. This requires a way to make a copy of the message, which I've done with `dbus_message_copy`. (It's not quite a clone, because it can fail.) Following previous comments, I've made the new behaviour optional, and only for signals not other kinds of messages. Existing behaviour is maintained by default.

This fixes #346.