### PR TITLE
Fixing `org.freedesktop.DBus.Properties.GetAll` For Interfaces With Asynchronous Properties

### DIFF
--- a/dbus-crossroads/Cargo.toml
+++ b/dbus-crossroads/Cargo.toml
@@ -14,5 +14,9 @@ readme = "README.md"
 [dependencies]
 dbus = { path = "../dbus", version = "0.9.3" }
 
+[dev-dependencies]
+tokio = { version = "1.14.0", features = ["rt", "test-util", "macros", "sync"] }
+dbus-tokio = { path = "../dbus-tokio" }
+
 [badges]
 maintenance = { status = "actively-developed" }

--- a/dbus-crossroads/src/stdimpl.rs
+++ b/dbus-crossroads/src/stdimpl.rs
@@ -112,6 +112,13 @@ impl PropContext {
     }
 
     pub (crate) fn set_send_on_drop(&mut self, value: Arc<dyn Sender + Send + Sync>) {
+        if let Some(get_all) = &self.get_all {
+            let mut pactx = get_all.lock().unwrap();
+            if let Some(ref mut propctx) = pactx.propctx {
+                propctx.context.as_mut().map(|ctx| ctx.set_send_on_drop(value));
+                return;
+            }
+        }
         self.context.as_mut().map(|ctx| ctx.set_send_on_drop(value));
     }
 


### PR DESCRIPTION
This pull request enables sending the response on `Context` dropping for `org.freedesktop.DBus.Properties`'s `GetAll` method's handler.

## Why?

When the `GetAll` method is called for an interface with at least one async property, `dbus-crossroads` does not send a result response: the handler's execution finishes (and `flush_messages` is called) before the reply is constructed.

#### Minimal (not) working example:
```rust
use dbus::channel::MatchingReceiver;
use dbus::message::MatchRule;
use dbus_crossroads::Crossroads;
use dbus_tokio::connection;
use futures::future;

#[tokio::main]
pub async fn main() {
    let (resource, c) = connection::new_session_sync().unwrap();
    tokio::spawn(async { resource.await; });
    c.request_name("com.example.dbustest", false, true, false).await.unwrap();

    let mut cr = Crossroads::new();
    cr.set_async_support(Some((c.clone(), Box::new(|x| { tokio::spawn(x); }))));
    let iface_token = cr.register("com.example.dbustest", |b| {
        b.property("One").get(|_, _| Ok(1));
        // b.property("Two").get(|_, _| Ok(2));
        b.property("Two") .get_async(|mut ctx, _| async move { 
            ctx.reply(Ok(2))
        });
    });
    cr.insert("/", &[iface_token], ());

    c.start_receive(MatchRule::new_method_call(), Box::new(move |msg, conn| {
        cr.handle_message(msg, conn).unwrap();
        true
    }));
    future::pending::<()>().await;
}
```
```bash
dbus-send --print-reply --dest=com.example.dbustest / org.freedesktop.DBus.Properties.GetAll string:'com.example.dbustes'
````
It hangs. Note if the async property is replaced with synchronous (commented out), the program responds to the method call as expected.

## Testing

This PR introduces two new tests in the `dbus-crossroads` crate for the implementation of `GetAll`. One is completely synchronous and worked before the fix and another declares an interface with an async property using `dbus-tokio` (which would hang until timeout). I had to add `tokio` and `dbus-tokio` as dev. dependencies to `dbus-crossroads` for it to work.