### PR TITLE
crossroads: fix for annotations moving self, breaking cr.register()

### DIFF
--- a/dbus-crossroads/src/ifacedesc.rs
+++ b/dbus-crossroads/src/ifacedesc.rs
@@ -610,11 +610,11 @@ impl<T: Send + 'static> IfaceBuilder<T> {
         }
     }
 
-    pub fn annotate<N: Into<String>, V: Into<String>>(mut self, name: N, value: V) -> Self {
+    pub fn annotate<N: Into<String>, V: Into<String>>(&mut self, name: N, value: V) -> &mut Self {
         self.0.annotations.insert(name, value);
         self
     }
-    pub fn deprecated(self) -> Self { self.annotate(DEPRECATED, "true") }
+    pub fn deprecated(&mut self) -> &mut Self { self.annotate(DEPRECATED, "true") }
 
     pub (crate) fn build<F>(name: Option<strings::Interface<'static>>, f: F) -> IfaceDesc
     where F: FnOnce(&mut IfaceBuilder<T>) {


### PR DESCRIPTION
Inside a crossroads-generated the `register()` function, interface annotations cause compilation errors because the closure is passed a mutable reference, but the `annotate()` method wants to consume `self`.

Changing the `self` and return types for `annotate()` to be mutable references resolves the issue, while still allowing chaining.

The issue can be observed by using dbus-codegen to generate a crossroads interface for [org.mpris.MediaPlayer2.xml](https://gitlab.freedesktop.org/mpris/mpris-spec/-/blob/master/spec/org.mpris.MediaPlayer2.xml):

```
pub fn register_org_mpris_media_player2<T>(cr: &mut crossroads::Crossroads) -> crossroads::IfaceToken<T>
where T: OrgMprisMediaPlayer2 + Send + 'static
{
    cr.register("org.mpris.MediaPlayer2", |b| {

        b.annotate("org.freedesktop.DBus.Property.EmitsChangedSignal", "true");
        b.method("Raise", (), (), |_, t: &mut T, ()| {
            t.raise()
        });
        b.method("Quit", (), (), |_, t: &mut T, ()| {
            t.quit()
        });
        ...
    })
}
```

And the implementation of `IfaceBuilder<T>::annotate()` looks like this:

```
 pub fn annotate<N: Into<String>, V: Into<String>>(mut self, name: N, value: V) -> Self {
     self.0.annotations.insert(name, value);
     self
 }
```

The generated code compiles with the error

```
error[E0507]: cannot move out of `*b` which is behind a mutable reference
  --> .../target/debug/build/panharmonicon-e8c2790e09b593de/out/org.mpris.MediaPlayer2.rs:27:9
   |
27 |         b.annotate("org.freedesktop.DBus.Property.EmitsChangedSignal", "true");
   |         ^ move occurs because `*b` has type `IfaceBuilder<T>`, which does not implement the `Copy` trait

For more information about this error, try `rustc --explain E0507`.
```

By changing `annotate()` and related method `deprecated()` to take by reference rather than move self, the generated code compiles.