### PR TITLE
Port dbus-rs to rustix.

### DIFF
--- a/dbus-native-channel/Cargo.toml
+++ b/dbus-native-channel/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.80"
+rustix = "0.33.0"

--- a/dbus-native-channel/src/sys.rs
+++ b/dbus-native-channel/src/sys.rs
@@ -1,8 +1,7 @@
 use std::os::unix::net::UnixStream;
 
 pub fn getuid() -> u32 {
-    let x = unsafe { libc::getuid() };
-    x as u32
+    rustix::process::getuid().as_raw()
 }
 
 pub fn connect_blocking(addr: &libc::sockaddr_un) -> Result<UnixStream, Box<dyn std::error::Error>> {

--- a/dbus-native/Cargo.toml
+++ b/dbus-native/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.66"
 dbus-strings = { path = "../dbus-strings" }
 dbus-native-channel = { path = "../dbus-native-channel" }

--- a/dbus-tokio/Cargo.toml
+++ b/dbus-tokio/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 dbus = { path = "../dbus", version = "0.9", features=["futures"] }
-libc = "0.2.69"
+rustix = "0.33.0"
 tokio = {version = "1.0", features=["time", "net"]}
 dbus-crossroads = { path = "../dbus-crossroads", optional = true, version = "0.5" }
 

--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.66"
+rustix = "0.33.0"
 libdbus-sys = { path = "../libdbus-sys", version = "0.2.2" }
 futures-util = { version = "0.3", optional = true, default-features = false }
 futures-channel = { version = "0.3", optional = true }

--- a/dbus/src/ffidisp/watch.rs
+++ b/dbus/src/ffidisp/watch.rs
@@ -12,6 +12,7 @@ use std::os::windows::io::{RawSocket, AsRawSocket};
 use libc::{POLLIN, POLLOUT, POLLERR, POLLHUP};
 #[cfg(windows)]
 use winapi::um::winsock2::{POLLIN, POLLOUT, POLLERR, POLLHUP};
+use rustix::fd::{BorrowedFd, AsFd};
 use std::os::raw::{c_void, c_uint};
 
 /// A file descriptor to watch for incoming events (for async I/O).
@@ -108,9 +109,19 @@ impl AsRawFd for Watch {
     fn as_raw_fd(&self) -> RawFd { self.fd }
 }
 
+#[cfg(unix)]
+impl AsFd for Watch {
+    fn as_fd(&self) -> BorrowedFd { unsafe { BorrowedFd::borrow_raw_fd(self.fd) } }
+}
+
 #[cfg(windows)]
 impl AsRawSocket for Watch {
     fn as_raw_socket(&self) -> RawSocket { self.fd }
+}
+
+#[cfg(windows)]
+impl AsSocket for Watch {
+    fn as_socket(&self) -> BorrowedSocket { unsafe { BorrowedSocket::borrow_raw_socket(self.fd) } }
 }
 
 /// Note - internal struct, not to be used outside API. Moving it outside its box will break things.


### PR DESCRIPTION
This ports dbus-rs from using the libc crate directly to using rustix, a syscall
wrapper crate with a focus on safe APIs. This factors out some unsafe blocks and
manual error handling.

This PR doesn't completely replace libc, as dbus-rs uses several libc types in
its public API, and this PR seeks to avoid changing the public API.

