### PR TITLE
crossroads: Remove requirement of having properties for object manager

### DIFF
--- a/dbus-crossroads/src/stdimpl.rs
+++ b/dbus-crossroads/src/stdimpl.rs
@@ -284,7 +284,6 @@ fn get_all_for_path<F: FnOnce(&mut IfaceContext) + Send + 'static>(path: &dbus::
     let ictx: Arc<Mutex<IfaceContext>> = Default::default();
     let (reg, ifaces) = cr.registry_and_ifaces(&path);
     let all: Vec<_> = ifaces.into_iter().filter_map(|&token| {
-        if !reg.has_props(token) { return None };
         let iface_name = reg.get_intf_name(token)?;
         Some(PropContext {
             context: None,

--- a/dbus-crossroads/src/test.rs
+++ b/dbus-crossroads/src/test.rs
@@ -206,7 +206,7 @@ fn object_manager() {
     let radius_iface = &omia.interfaces["com.example.dbusrs.radius"]["Radius"];
     let radius = radius_iface.0.as_u64().unwrap();
     assert_eq!(radius, 10);
-    assert!(omia.interfaces.get("org.freedesktop.DBus.Introspectable").is_none());
+    assert!(omia.interfaces.get("org.freedesktop.DBus.Introspectable").is_some());
 
     let msg = Message::new_method_call("com.example.dbusrs.crossroads.score", "/list",
         "org.freedesktop.DBus.ObjectManager", "GetManagedObjects").unwrap();


### PR DESCRIPTION
The D-Bus specification does not require properties to exist for an
object path to be advertised in ObjectManager
(https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager).