### PR TITLE
README.md: made crossroads example compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ c.request_name("com.example.dbustest", false, true, false)?;
 let mut cr = Crossroads::new();
 let token = cr.register("com.example.dbustest", |b| {
     b.method("Hello", ("name",), ("reply",), |_, _, (name,): (String,)| {
-        Ok(format!("Hello {}!", name))
+        Ok((format!("Hello {}!", name),))
     });
 });
 cr.insert("/hello", &[token], ());


### PR DESCRIPTION
closure passed to b.method returns tuple instead of String