### PR TITLE
crossroads: Support "" as interface name in org.freedesktop.DBus.Properties.GetAll

### DIFF
--- a/dbus-crossroads/src/stdimpl.rs
+++ b/dbus-crossroads/src/stdimpl.rs
@@ -227,7 +227,19 @@ fn get(mut ctx: Context, cr: &mut Crossroads, (interface_name, property_name): (
     propctx.call_prop(cr, false).map(|propctx| { propctx.context.unwrap() })
 }
 
+fn getall_all(ctx: Context, cr: &mut Crossroads) -> Option<Context> {
+    get_all_for_path(&ctx.path().clone(), cr, Some(ctx), move |ictx, octx| {
+        let props: HashMap<_, _> = ictx.ifaces.values().flatten().collect();
+        octx.as_mut().unwrap().do_reply(|msg| {
+            msg.append_all((props,));
+        });
+    })
+}
+
 fn getall(mut ctx: Context, cr: &mut Crossroads, (interface_name,): (String,)) -> Option<Context> {
+    if interface_name == "" {
+        return getall_all(ctx, cr);
+    }
     let mut propctx = match ctx.check(|ctx| { PropContext::new(cr, ctx.path().clone(), interface_name, "".into())}) {
         Ok(p) => p,
         Err(_) => return Some(ctx),

--- a/dbus-crossroads/src/test.rs
+++ b/dbus-crossroads/src/test.rs
@@ -272,6 +272,38 @@ fn properties_get_all() {
     assert_eq!(response.len(), 2);
 }
 
+#[test]
+fn properties_multi_interface_get_all() {
+    let bus = dbus::blocking::Connection::new_session().unwrap();
+    bus.request_name("com.example.dbusrs.properties", false, false, false).unwrap();
+
+    let mut cr = Crossroads::new();
+    let iface = cr.register("com.example.dbusrs.properties", |b| {
+        b.property("One").get(|_, _| Ok(1));
+        b.property("Two").get(|_, _| Ok(2));
+    });
+    let iface2 = cr.register("com.example.dbusrs.more_properties", |b| {
+        b.property("Three").get(|_, _| Ok(3));
+        b.property("Four").get(|_, _| Ok(4));
+    });
+    cr.insert("/", &[iface, iface2], ());
+
+    let msg = Message::call_with_args(
+        "com.example.dbusrs.properties",
+        "/",
+        "org.freedesktop.DBus.Properties",
+        "GetAll",
+        ("",),
+    );
+    let r = dispatch_helper(&mut cr, msg);
+    let response: HashMap<String, Variant<Box<dyn RefArg>>> = r.read1().unwrap();
+    assert_eq!(response.get("One").unwrap().as_i64(), Some(1));
+    assert_eq!(response.get("Two").unwrap().as_i64(), Some(2));
+    assert_eq!(response.get("Three").unwrap().as_i64(), Some(3));
+    assert_eq!(response.get("Four").unwrap().as_i64(), Some(4));
+    assert_eq!(response.len(), 4);
+}
+
 #[tokio::test]
 async fn properties_get_all_async() {
     use dbus::channel::MatchingReceiver;


### PR DESCRIPTION
The spec [0] allows passing an empty string as the interface name for all methods of the org.freedesktop.DBus.Properties interface.  This implementation doesn't cover the Get or Set methods, but does at least add support for it in GetAll.

[0] https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties