### PR TITLE
Add `io-lifetimes` feature to implement traits for standard `OwnedFd`

### DIFF
--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -14,6 +14,7 @@ readme = "../README.md"
 edition = "2018"
 
 [dependencies]
+io-lifetimes = { version = "1.0.3", optional = true }
 libc = "0.2.66"
 libdbus-sys = { path = "../libdbus-sys", version = "0.2.2" }
 futures-util = { version = "0.3", optional = true, default-features = false }

--- a/dbus/src/arg/basic_impl.rs
+++ b/dbus/src/arg/basic_impl.rs
@@ -251,6 +251,26 @@ impl<'a> Get<'a> for OwnedFd {
     }
 }
 
+#[cfg(all(unix, feature = "io-lifetimes"))]
+impl Arg for io_lifetimes::OwnedFd {
+    const ARG_TYPE: ArgType = ArgType::UnixFd;
+    fn signature() -> Signature<'static> { unsafe { Signature::from_slice_unchecked("h\0") } }
+}
+#[cfg(all(unix, feature = "io-lifetimes"))]
+impl Append for io_lifetimes::OwnedFd {
+    fn append_by_ref(&self, i: &mut IterAppend) {
+        arg_append_basic(&mut i.0, ArgType::UnixFd, self.as_raw_fd())
+    }
+}
+#[cfg(all(unix, feature = "io-lifetimes"))]
+impl DictKey for io_lifetimes::OwnedFd {}
+#[cfg(all(unix, feature = "io-lifetimes"))]
+impl<'a> Get<'a> for io_lifetimes::OwnedFd {
+    fn get(i: &mut Iter) -> Option<Self> {
+        arg_get_basic(&mut i.0, ArgType::UnixFd).map(|fd| unsafe { io_lifetimes::OwnedFd::from_raw_fd(fd) })
+    }
+}
+
 #[cfg(unix)]
 refarg_impl!(OwnedFd, _i, { use std::os::unix::io::AsRawFd; Some(_i.as_raw_fd() as i64) }, None, None, None);
 


### PR DESCRIPTION
On a recent Rust version this re-exports the standard library, otherwise it provides an equivalent version.

When `dbus-rs` requires a Rust version that has this type in std, the feature can be change to do nothing, and it can just use the standard library version.