### PR TITLE
2c std ownedfd

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,11 @@ Features
 
 The `futures` feature makes `dbus` depend on the `futures` crate. This enables the `nonblock` module (used by the `dbus-tokio` crate).
 
-The `no-string-validation` feature skips an extra check that a specific string (e g a `Path`, `ErrorName` etc) conforms to the D-Bus specification, which might also make things a tiny bit faster. But - if you do so, and then actually send invalid strings to the D-Bus library, you might get a panic instead of a proper error.
-
 The `vendored` feature links libdbus statically into the final executable.
+
+The `io-lifetimes` feature adds a dependency on the `io-lifetimes` crate, enabling you to append and get std's `OwnedFd`.
+
+The `no-string-validation` feature skips an extra check that a specific string (e g a `Path`, `ErrorName` etc) conforms to the D-Bus specification, which might also make things a tiny bit faster. But - if you do so, and then actually send invalid strings to the D-Bus library, you might get a panic instead of a proper error.
 
 Requirements
 ============

--- a/dbus/src/arg/array_impl.rs
+++ b/dbus/src/arg/array_impl.rs
@@ -612,7 +612,10 @@ pub fn get_array_refarg(i: &mut Iter) -> Box<dyn RefArg> {
                 _ => panic!("Array with invalid dictkey ({:?})", key),
             }
         }
-        ArgType::UnixFd => get_var_array_refarg::<OwnedFd, _>(i, |si| si.get()),
+        #[cfg(unix)]
+        ArgType::UnixFd => get_var_array_refarg::<std::os::fd::OwnedFd, _>(i, |si| si.get()),
+        #[cfg(windows)]
+        ArgType::UnixFd => panic!("Fd passing not supported on windows"),
         ArgType::Struct => get_internal_array(i),
     };
 

--- a/dbus/src/arg/basic_impl.rs
+++ b/dbus/src/arg/basic_impl.rs
@@ -271,6 +271,7 @@ impl<'a> Get<'a> for io_lifetimes::OwnedFd {
     }
 }
 
+
 #[cfg(unix)]
 refarg_impl!(OwnedFd, _i, { use std::os::unix::io::AsRawFd; Some(_i.as_raw_fd() as i64) }, None, None, None);
 
@@ -310,6 +311,25 @@ impl RefArg for File {
     fn signature(&self) -> Signature<'static> { <File as Arg>::signature() }
     #[inline]
     fn append(&self, i: &mut IterAppend) { <File as Append>::append_by_ref(self, i) }
+    #[inline]
+    fn as_any(&self) -> &dyn any::Any { self }
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn any::Any { self }
+    #[cfg(unix)]
+    #[inline]
+    fn as_i64(&self) -> Option<i64> { Some(self.as_raw_fd() as i64) }
+    #[inline]
+    fn box_clone(&self) -> Box<dyn RefArg + 'static> { Box::new(self.try_clone().unwrap()) }
+}
+
+#[cfg(all(unix, feature = "io-lifetimes"))]
+impl RefArg for io_lifetimes::OwnedFd {
+    #[inline]
+    fn arg_type(&self) -> ArgType { <Self as Arg>::ARG_TYPE }
+    #[inline]
+    fn signature(&self) -> Signature<'static> { <Self as Arg>::signature() }
+    #[inline]
+    fn append(&self, i: &mut IterAppend) { <Self as Append>::append_by_ref(self, i) }
     #[inline]
     fn as_any(&self) -> &dyn any::Any { self }
     #[inline]


### PR DESCRIPTION
Remove our own OwnedFd since std has one now. Backwards incompatible change, and bumps rust version requirement to 1.63. 