### PR TITLE
Fix potential null pointer dereference

### DIFF
--- a/libdbus-sys/build_vendored.rs
+++ b/libdbus-sys/build_vendored.rs
@@ -131,7 +131,6 @@ const CWARNINGS: &'static [&'static str] = &[
     "-Wmissing-format-attribute",
     "-Wmissing-include-dirs",
     "-Wmissing-noreturn",
-    "-Wnull-dereference",
     "-Wpacked",
     "-Wpointer-arith",
     "-Wredundant-decls",


### PR DESCRIPTION
Ubuntu 20.04 + gcc 9.4.0

```toml
dbus = {version = "0.9.7", features = ["vendored"]}
```

**Command:** `cargo build --target arm-unknown-linux-gnueabi --release`

**Error:**

```log
  running: "arm-linux-gnueabi-gcc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-march=armv6" "-marm" "-mfloat-abi=soft" "-static" "-I" "./vendor/dbus/" "-Wall" "-Wextra" "-UDBUS_DISABLE_CHECKS" "-UWORDS_BIGENDIAN" "-UHAVE_GETPEERUCRED" "-UHAVE_CMSGCRED" "-Wno-missing-field-initializers" "-Wno-unused-parameter" "-Wno-error=duplicated-branches" "-Wno-error=cast-align" "-Wno-error=sign-compare" "-Wno-error=unused-but-set-variable" "-Warray-bounds" "-Wchar-subscripts" "-Wdouble-promotion" "-Wduplicated-branches" "-Wduplicated-cond" "-Wfloat-equal" "-Wformat-nonliteral" "-Wformat-security" "-Wformat=2" "-Winit-self" "-Winline" "-Wlogical-op" "-Wmissing-declarations" "-Wmissing-format-attribute" "-Wmissing-include-dirs" "-Wmissing-noreturn" "-Wnull-dereference" "-Wpacked" "-Wpointer-arith" "-Wredundant-decls" "-Wrestrict" "-Wreturn-type" "-Wshadow" "-Wstrict-aliasing" "-Wswitch-default" "-Wswitch-enum" "-Wundef" "-Wunused-but-set-variable" "-Wwrite-strings" "-Wdeclaration-after-statement" "-Wimplicit-function-declaration" "-Wjump-misses-init" "-Wmissing-prototypes" "-Wnested-externs" "-Wold-style-definition" "-Wpointer-sign" "-Wstrict-prototypes" "-fno-strict-aliasing" "-DDBUS_MINOR_VERSION=14" "-DDBUS_SESSION_BUS_CONNECT_ADDRESS=\"autolaunch:\"" "-DDBUS_ENABLE_CHECKS" "-DDBUS_DISABLE_ASSERT" "-DVERSION=\"1.14.4\"" "-DHAVE_BYTESWAP_H" "-DDBUS_SESSION_SOCKET_DIR=\"/tmp\"" "-DDBUS_INT64_MODIFIER" "-DDBUS_VERSION=69124" "-DDBUS_MAJOR_VERSION=1" "-DHAVE_ERRNO_H" "-DDBUS_SIZEOF_VOID_P=4" "-DHAVE_LOCALE_H" "-DHAVE_UNIX_FD_PASSING" "-DDBUS_USE_SYNC" "-DDBUS_HAVE_LINUX_EPOLL" "-DDBUS_MACHINE_UUID_FILE=\"/etc/machine-id\"" "-DDBUS_HAVE_INT64" "-DHAVE_DECL_MSG_NOSIGNAL" "-DHAVE_EPOLL" "-DHAVE_SOCKLEN_T" "-D_GNU_SOURCE" "-DDBUS_MICRO_VERSION=4" "-DHAVE_DECL_ENVIRON" "-DDBUS_VERSION_STRING=\"1.14.4\"" "-DDBUS_UNIX" "-DDBUS_COMPILATION" "-DHAVE_GETPWNAM_R" "-DDBUS_SYSTEM_BUS_DEFAULT_ADDRESS=\"unix:path=/run/dbus/system_bus_socket\"" "-Werror" "-o" "/mnt/d/projects/xxx/target/arm-unknown-linux-gnueabi/release/build/libdbus-sys-535689dc4f112b36/out/./vendor/dbus/dbus/dbus-sysdeps-unix.o" "-c" "./vendor/dbus/dbus/dbus-sysdeps-unix.c"
  cargo:warning=./vendor/dbus/dbus/dbus-sysdeps-unix.c: In function ‘_dbus_write_socket_with_unix_fds_two’:
  cargo:warning=./vendor/dbus/dbus/dbus-sysdeps-unix.c:619:21: error: potential null pointer dereference [-Werror=null-dereference]
  cargo:warning=  619 |       cm->cmsg_type = SCM_RIGHTS;
  cargo:warning=      |                     ^
  cargo:warning=./vendor/dbus/dbus/dbus-sysdeps-unix.c:620:20: error: potential null pointer dereference [-Werror=null-dereference]
  cargo:warning=  620 |       cm->cmsg_len = CMSG_LEN(n_fds * sizeof(int));
  cargo:warning=      |                    ^
  cargo:warning=./vendor/dbus/dbus/dbus-sysdeps-unix.c:618:22: error: potential null pointer dereference [-Werror=null-dereference]
  cargo:warning=  618 |       cm->cmsg_level = SOL_SOCKET;
  cargo:warning=      |                      ^
  cargo:warning=cc1: all warnings being treated as errors
  exit status: 1

  --- stderr
```