### PR TITLE
Provide set_sender for message

### DIFF
--- a/dbus-native/src/message.rs
+++ b/dbus-native/src/message.rs
@@ -133,6 +133,8 @@ impl<'a> Message<'a> {
 
     pub fn set_serial(&mut self, value: Option<std::num::NonZeroU32>) { self.serial = value; }
 
+    pub fn set_sender(&mut self, value: Option<Cow<'a, strings::BusName>>) { self.sender = value; }
+
     pub fn serial(&self) -> Option<std::num::NonZeroU32> { self.serial }
 
     pub fn set_flags(&mut self, value: u8) { self.flags = value & 0x7; }

--- a/libdbus-sys/src/lib.rs
+++ b/libdbus-sys/src/lib.rs
@@ -233,6 +233,7 @@ extern "C" {
     pub fn dbus_message_get_member(message: *mut DBusMessage) -> *const c_char;
     pub fn dbus_message_get_sender(message: *mut DBusMessage) -> *const c_char;
     pub fn dbus_message_set_serial(message: *mut DBusMessage, serial: u32);
+    pub fn dbus_message_set_sender(message: *mut DBusMessage, sender: *const c_char) -> u32;
     pub fn dbus_message_set_destination(message: *mut DBusMessage, destination: *const c_char) -> u32;
     pub fn dbus_message_get_no_reply(message: *mut DBusMessage) -> u32;
     pub fn dbus_message_set_no_reply(message: *mut DBusMessage, no_reply: u32);


### PR DESCRIPTION
Similar to set_serial, set_sender is useful when generating a message that was not received from a real D-Bus instance, especially for testing message processors that rely on a correctly set sender.