### PR TITLE
change dbus submodule repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libdbus-sys/vendor/dbus"]
 	path = libdbus-sys/vendor/dbus
-	url = https://github.com/freedesktop/dbus.git
+	url = https://gitlab.freedesktop.org/dbus/dbus.git


### PR DESCRIPTION
Apparently, freedesktop.org removed everything from Github and is now available at https://gitlab.freedesktop.org