### PR TITLE
Allow hiding the Introspectable interface

### DIFF
--- a/dbus-crossroads/src/crossroads.rs
+++ b/dbus-crossroads/src/crossroads.rs
@@ -13,6 +13,7 @@ use crate::utils::Dbg;
 const INTROSPECTABLE: usize = 0;
 const PROPERTIES: usize = 1;
 const OBJECT_MANAGER: usize = 2;
+const INTROSPECTABLE_HIDDEN: usize = 3;
 
 /// Contains a reference to a registered interface.
 pub struct IfaceToken<T: Send + 'static>(usize, PhantomData<&'static T>);
@@ -85,9 +86,11 @@ impl Crossroads {
         let t0 = stdimpl::introspectable(&mut cr);
         let t1 = stdimpl::properties(&mut cr);
         let t2 = stdimpl::object_manager(&mut cr);
+        let t3 = stdimpl::introspectable_hidden(&mut cr);
         debug_assert_eq!(t0.0, INTROSPECTABLE);
         debug_assert_eq!(t1.0, PROPERTIES);
         debug_assert_eq!(t2.0, OBJECT_MANAGER);
+        debug_assert_eq!(t3.0, INTROSPECTABLE_HIDDEN);
 
         // Add the root path and make it introspectable. This helps D-Bus debug tools
         cr.insert("/", &[], ());
@@ -285,6 +288,10 @@ impl Crossroads {
 
     /// The token representing the built-in implementation of "org.freedesktop.DBus.Introspectable".
     pub fn introspectable<T: Send + 'static>(&self) -> IfaceToken<T> { IfaceToken(INTROSPECTABLE, PhantomData) }
+
+    /// The token representing a built-in implementation of "org.freedesktop.DBus.Introspectable",
+    /// but including a `Hidden` property, thus it not being visible in the introspection.
+    pub fn hidden_introspectable<T: Send + 'static>(&self) -> IfaceToken<T> { IfaceToken(INTROSPECTABLE_HIDDEN, PhantomData) }
 
     /// The token representing the built-in implementation of "org.freedesktop.DBus.Properties".
     pub fn properties<T: Send + 'static>(&self) -> IfaceToken<T> { IfaceToken(PROPERTIES, PhantomData) }

--- a/dbus-crossroads/src/stdimpl.rs
+++ b/dbus-crossroads/src/stdimpl.rs
@@ -34,6 +34,15 @@ pub fn introspectable(cr: &mut Crossroads) -> IfaceToken<()> {
     })
 }
 
+pub fn introspectable_hidden(cr: &mut Crossroads) -> IfaceToken<()> {
+    cr.register("org.freedesktop.DBus.Introspectable", |b| {
+        b.hidden();
+        b.method_with_cr("Introspect", (), ("xml_data",), |ctx, cr, _: ()| {
+            Ok((introspect(cr, ctx.path()),))
+        });
+    })
+}
+
 
 pub (crate) fn make_emits_message<V: dbus::arg::Arg + dbus::arg::Append>(prop_name: &str, emits_changed: &str, ctx: &Context, v: &V) -> Option<dbus::Message> {
     let arr = [prop_name];

--- a/dbus-crossroads/src/test.rs
+++ b/dbus-crossroads/src/test.rs
@@ -180,6 +180,25 @@ fn introspect() {
     assert_eq!(INTROSPECT, xml_data);
 }
 
+const INTROSPECT_ROOT: &str = r###"<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/com">
+</node>"###;
+
+#[test]
+fn introspect_hidden() {
+    let mut cr = Crossroads::new();
+    cr.set_add_standard_ifaces(false);
+    cr.insert("/com", &[cr.hidden_introspectable()], ());
+
+    let msg = Message::new_method_call("com.example.dbusrs.crossroads.score", "/com",
+           "org.freedesktop.DBus.Introspectable", "Introspect").unwrap();
+    let r = dispatch_helper(&mut cr, msg);
+    let xml_data: &str = r.read1().unwrap();
+    println!("{}", xml_data);
+    assert_eq!(INTROSPECT_ROOT, xml_data);
+}
+
 #[test]
 fn object_manager() {
     struct Apple { radius: u32, weight: u32 }


### PR DESCRIPTION
## Motivation

Many real-world applications hide the existence of the `org.freedesktop.DBus.Introspectable` interface on several nodes, yet provide introspection capabilities on these nodes. This primarily happens on intermediate nodes which do not have any other functionality.

The reason for this seems to be to make DBus GUI tools nicer to use. D-Feet, or example, hides nodes that don't have any interfaces visible. That way, if you, for example, just have an object at `/com/example/test_object`, just that path will be shown, instead of three paths: `/com`, `/com/example`, and `/com/example/test_object`.

## Change Description

I added a `hidden` field to `IfaceDesc`, `MethodDesc`, `SignalDesc`, and `PropDesc`. The goal of this PR would only require it to be added to `IfaceDesc`, but for completeness sake, That property defaults to `false`, and if it is set (by the `hidden` function on the `IfaceBuilder`, `MethodDesc`, `SignalBuilder`, or `PropBuilder`.

## Why Draft?

I don't think the way I did it is the best way. Maybe instead of setting a property on the interface to hide, we should add an additional list to `Object` to represent interfaces hidden from introspection. A prior version of this PR used annotations to store the `hidden` flag, but as it is not useful to render in the introspection, that was dropped.