### PR TITLE
Allow hiding interfaces on objects

### DIFF
--- a/dbus-crossroads/src/stdimpl.rs
+++ b/dbus-crossroads/src/stdimpl.rs
@@ -16,7 +16,7 @@ fn introspect(cr: &Crossroads, path: &dbus::Path<'static>) -> String {
         childstr += &format!("  <node name=\"{}\"/>\n", c);
     }
     let (reg, ifaces) = cr.registry_and_ifaces(path);
-    let ifacestr = reg.introspect(ifaces);
+    let ifacestr = reg.introspect(&ifaces);
 
     let nodestr = format!(
 r##"<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
@@ -302,7 +302,7 @@ where F: FnOnce(&mut IfaceContext, &mut Option<Context>) + Send + 'static {
 fn for_each_interface_with_properties<F: FnOnce(&mut IfaceContext, &mut Option<Context>) + Send + 'static, I: IntoIterator<Item = usize>>
 (path: &dbus::Path<'static>, ifaces: I, cr: &mut Crossroads, mut octx: Option<Context>, f: F) -> Option<Context> {
     let ictx: Arc<Mutex<IfaceContext>> = Default::default();
-    let (reg, _all_ifaces) = cr.registry_and_ifaces(&path);
+    let (reg, _ifaces) = cr.registry_and_ifaces(&path);
     let all: Vec<_> = ifaces.into_iter().filter_map(|token| {
         let iface_name = reg.get_intf_name(token)?;
         Some(PropContext {

--- a/dbus-crossroads/src/test.rs
+++ b/dbus-crossroads/src/test.rs
@@ -182,6 +182,27 @@ fn introspect() {
     assert_eq!(INTROSPECT, xml_data);
 }
 
+const INTROSPECT_ROOT: &str = r###"<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/com">
+</node>"###;
+
+#[test]
+fn introspect_hidden() {
+    let mut cr = Crossroads::new();
+    cr.insert("/com", &[], ());
+    cr.add_hidden_interface("/com", cr.introspectable::<()>());
+
+    let msg = Message::new_method_call("com.example.dbusrs.crossroads.score", "/com",
+                                       "org.freedesktop.DBus.Introspectable", "Introspect").unwrap();
+    let r = dispatch_helper(&mut cr, msg);
+    let xml_data: &str = r.read1().unwrap();
+    println!("{}", xml_data);
+    assert_eq!(INTROSPECT_ROOT, xml_data);
+}
+
+
+
 #[test]
 fn object_manager() {
     struct Apple { radius: u32, weight: u32 }


### PR DESCRIPTION
## Motivation

Many real-world applications hide the existence of the `org.freedesktop.DBus.Introspectable` interface on several nodes, yet provide introspection capabilities on these nodes. This primarily happens on intermediate nodes which do not have any other functionality.

The reason for this seems to be to make DBus GUI tools nicer to use. D-Feet, or example, hides nodes that don't have any interfaces visible. That way, if you, for example, just have an object at `/com/example/test_object`, just that path will be shown, instead of three paths: `/com`, `/com/example`, and `/com/example/test_object`.

## Change Description

I added a `hidden_interfaces` field which is excluded for the `object_manager` and `introspectable` interfaces. All other uses use a newly introduced `all_interfaces` method on `Object`.