### PR TITLE
Make clap dependency optional, but default & required for building the binary

### DIFF
--- a/dbus-codegen/Cargo.toml
+++ b/dbus-codegen/Cargo.toml
@@ -16,16 +16,17 @@ path = "src/lib.rs"
 [[bin]]
 name = "dbus-codegen-rust"
 path = "src/main.rs"
+required-features = ["clap"]
 
 [features]
-default = ["dbus"]
+default = ["dbus", "clap"]
 
 [dependencies]
 xml-rs = "0.8.3"
 dbus = { path = "../dbus", version = "0.9", optional = true }
 dbus-tree = { path = "../dbus-tree", version = "0.9", optional = true }
 dbus-crossroads = { path = "../dbus-crossroads", version = "0.5", optional = true }
-clap = "2.20"
+clap = { version = "2.20", optional = true }
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This is meant to make the `dbus-codegen` crate easier to use as a library (for instance, in build scripts) without having to pull in the clap crate.

This is not a breaking change for library users.