### PR TITLE
Switch from winapi to windows-sys

### DIFF
--- a/dbus/Cargo.toml
+++ b/dbus/Cargo.toml
@@ -22,7 +22,7 @@ futures-executor = { version = "0.3", optional = true }
 # dbus-native-channel = { path = "../dbus-native-channel", version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.0", features = ["winsock2"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
`winapi` hasn't been maintained for a number of years so most people are switching to `windows-sys`. Using the more common crate here reduces the chances of having to include both `winapi` and `windows-sys` in builds that depend on dbus.